### PR TITLE
Linux versions fix

### DIFF
--- a/lib/u3d/unity_version_number.rb
+++ b/lib/u3d/unity_version_number.rb
@@ -43,7 +43,7 @@ module U3d
   class UnityVersionComparator
     include Comparable
 
-    RELEASE_LETTER_STRENGTH = { a: 1, b: 2, f: 3, p: 4, xa: 1, xb: 2, xf: 3, xp: 4 }.freeze
+    RELEASE_LETTER_STRENGTH = { a: 1, b: 2, f: 3, p: 4 }.freeze
 
     attr_reader :version
 

--- a/lib/u3d/unity_version_number.rb
+++ b/lib/u3d/unity_version_number.rb
@@ -43,7 +43,7 @@ module U3d
   class UnityVersionComparator
     include Comparable
 
-    RELEASE_LETTER_STRENGTH = { a: 1, b: 2, f: 3, p: 4 }.freeze
+    RELEASE_LETTER_STRENGTH = { a: 1, b: 2, f: 3, p: 4, xa: 1, xb: 2, xf: 3, xp: 4 }.freeze
 
     attr_reader :version
 

--- a/lib/u3d/unity_versions.rb
+++ b/lib/u3d/unity_versions.rb
@@ -47,7 +47,9 @@ module U3d
     # Captures a version and its base url
     MAC_DOWNLOAD = %r{"(https?://[\w/\.-]+/[0-9a-f]{12}/)MacEditorInstaller/[a-zA-Z0-9/\.]+-(\d+\.\d+\.\d+\w\d+)\.?\w+"}
     WIN_DOWNLOAD = %r{"(https?://[\w/\.-]+/[0-9a-f]{12}/)Windows..EditorInstaller/[a-zA-Z0-9/\.]+-(\d+\.\d+\.\d+\w\d+)\.?\w+"}
-    LINUX_DOWNLOAD = %r{"(https?://[\w/\._-]+/unity\-editor\-installer\-(\d+\.\d+\.\d+\w\d+).*\.sh)"}
+    LINUX_DOWNLOAD_DATED = %r{"(https?://[\w/\._-]+/unity\-editor\-installer\-(\d+\.\d+\.\d+\w\d+).*\.sh)"}
+    LINUX_DOWNLOAD_RECENT_PAGE = %r{"(http://beta\.unity3d\.com/download/[a-zA-Z0-9/\.]+/public_download\.html)"}
+    LINUX_DOWNLOAD_RECENT_FILE = %r{'(https?://beta\.unity3d\.com/download/[a-zA-Z0-9/\.]+/unity\-editor\-installer\-(\d+\.\d+\.\d+\w+\d+).*\.sh)'}
     # Captures a beta version in html page
     UNITY_BETAVERSION_REGEX = %r{\/unity\/beta\/unity(\d+\.\d+\.\d+\w\d+)"}
     UNITY_EXTRA_DOWNLOAD_REGEX = %r{"(https?:\/\/[\w\/.-]+\.unity3d\.com\/(\w+))\/[a-zA-Z\/.-]+\/download.html"}
@@ -148,9 +150,29 @@ module U3d
           end
           data.gsub(/[ \t]+/, '').each_line { |l| puts l if /<a href=/ =~ l }
           versions = {}
-          results = data.scan(LINUX_DOWNLOAD)
+          results = data.scan(LINUX_DOWNLOAD_DATED)
           results.each do |capt|
             versions[capt[1]] = capt[0]
+          end
+
+          results = data.scan(LINUX_DOWNLOAD_RECENT_PAGE)
+          results.each do |page|
+            url = page[0]
+            uri = URI(url)
+            Net::HTTP.start(uri.host, uri.port) do |http|
+              request = Net::HTTP::Get.new uri
+              response = http.request request
+            end
+            if response.kind_of? Net::HTTPSuccess
+              capt = response.body.match(LINUX_DOWNLOAD_RECENT_FILE)
+              if capt && capt[1] && capt[2]
+                versions[capt[2]] = capt[1]
+              else
+                UI.error("Could not retrieve a fitting file from #{url}")
+              end
+            else
+              UI.error("Could not access #{url}")
+            end
           end
           if versions.count.zero?
             UI.important 'Found no releases'

--- a/lib/u3d/unity_versions.rb
+++ b/lib/u3d/unity_versions.rb
@@ -49,7 +49,7 @@ module U3d
     WIN_DOWNLOAD = %r{"(https?://[\w/\.-]+/[0-9a-f]{12}/)Windows..EditorInstaller/[a-zA-Z0-9/\.]+-(\d+\.\d+\.\d+\w\d+)\.?\w+"}
     LINUX_DOWNLOAD_DATED = %r{"(https?://[\w/\._-]+/unity\-editor\-installer\-(\d+\.\d+\.\d+\w\d+).*\.sh)"}
     LINUX_DOWNLOAD_RECENT_PAGE = %r{"(http://beta\.unity3d\.com/download/[a-zA-Z0-9/\.]+/public_download\.html)"}
-    LINUX_DOWNLOAD_RECENT_FILE = %r{'(https?://beta\.unity3d\.com/download/[a-zA-Z0-9/\.]+/unity\-editor\-installer\-(\d+\.\d+\.\d+\w+\d+).*\.sh)'}
+    LINUX_DOWNLOAD_RECENT_FILE = %r{'(https?://beta\.unity3d\.com/download/[a-zA-Z0-9/\.]+/unity\-editor\-installer\-(\d+\.\d+\.\d+(?:x)?\w\d+).*\.sh)'}
     # Captures a beta version in html page
     UNITY_BETAVERSION_REGEX = %r{\/unity\/beta\/unity(\d+\.\d+\.\d+\w\d+)"}
     UNITY_EXTRA_DOWNLOAD_REGEX = %r{"(https?:\/\/[\w\/.-]+\.unity3d\.com\/(\w+))\/[a-zA-Z\/.-]+\/download.html"}
@@ -166,7 +166,7 @@ module U3d
             if response.kind_of? Net::HTTPSuccess
               capt = response.body.match(LINUX_DOWNLOAD_RECENT_FILE)
               if capt && capt[1] && capt[2]
-                versions[capt[2]] = capt[1]
+                versions[capt[2].gsub(/x/, '')] = capt[1]
               else
                 UI.error("Could not retrieve a fitting file from #{url}")
               end

--- a/lib/u3d/utils.rb
+++ b/lib/u3d/utils.rb
@@ -30,7 +30,7 @@ module U3d
   module Utils
     # Regex to capture each part of a version string (0.0.0x0)
     CSIDL_LOCAL_APPDATA = 0x001c
-    UNITY_VERSION_REGEX = /(\d+)(?:\.(\d+)(?:\.(\d+))?)?(?:(\w)(?:(\d+))?)?/
+    UNITY_VERSION_REGEX = /(\d+)(?:\.(\d+)(?:\.(\d+))?)?(?:(\w+)(?:(\d+))?)?/
 
     class << self
       def get_ssl(url, redirect_limit: 10)


### PR DESCRIPTION
The LOG_RULES.md had some typos left, and some inconsistencies that needed tackling.

The installer.rb undergoes two modifications:
 * The Runner class, used to run Unity, has been moved to a separate file to further increase clarity.
 * Installer was asking to sanitize at each package installation when several were installed at once. Minor changes have been made so that the sanitation is offered only once. NOTE: the installation methods are now instance methods and no longer class methods.

Small fix regarding Linux versions, versions above 5.5.0 should now be listed as well.