### PR TITLE
Fix tail logs synchronization

### DIFF
--- a/lib/u3d/unity_runner.rb
+++ b/lib/u3d/unity_runner.rb
@@ -36,10 +36,7 @@ module U3d
         log_file = installation.default_log_file
       end
 
-      unless File.exist? log_file
-        temp = File.new(log_file, 'a')
-        temp.close
-      end
+      FileUtils.touch(log_file) unless File.exist? log_file
 
       tail_thread = Thread.new do
         begin

--- a/lib/u3d/unity_runner.rb
+++ b/lib/u3d/unity_runner.rb
@@ -36,7 +36,10 @@ module U3d
         log_file = installation.default_log_file
       end
 
-      FileUtils.touch(log_file)
+      unless File.exist? log_file
+        temp = File.new(log_file, 'a')
+        temp.close
+      end
 
       tail_thread = Thread.new do
         begin
@@ -52,6 +55,10 @@ module U3d
         end
       end
 
+      # Wait for tail_thread setup to be complete
+      sleep 0.5 while tail_thread.status!='sleep'
+      tail_thread.run
+
       begin
         args.unshift(installation.exe_path)
         if Helper.windows?
@@ -61,7 +68,7 @@ module U3d
         end
         U3dCore::CommandExecutor.execute(command: args)
       ensure
-        sleep 0.5
+        sleep 1
         Thread.kill(tail_thread)
       end
     end
@@ -89,7 +96,8 @@ module U3d
         f.extend File::Tail
         f.interval = 0.1
         f.max_interval = 0.4
-        f.backward 100
+        f.backward 0
+        Thread.stop
         f.tail { |l| yield l }
       end
     end


### PR DESCRIPTION
**Issue**

Sometimes u3d failed to catch the beginning of the logs, and therefore missed releveant pieces of information.

**Reason**

The tailing is done on a separated thread than the one launching Unity. Both of the threads can have different time to setup and start behaving as intended, and it could happen that the tailing wasn't completly setup when Unity started logging, resulting in the loss of the very first few logs.

**Fix**

Quite simply, wait for the tail thread to be completly setup, then start Unity. The tailing thread will now properly parse the first logs!