### PR TITLE
Better support for /dev/stdout (#11)

### DIFF
--- a/examples/Example2/fastlane/Fastfile
+++ b/examples/Example2/fastlane/Fastfile
@@ -2,3 +2,7 @@ desc "Run the EditorRun.Build task"
 lane :u3d_build do |options|
   u3d(raw_logs: options[:raw_logs], run_args: "-logFile './editor.log' -executeMethod U3d.EditorRun.Build -quit -batchmode")
 end
+
+lane :u3d_build2 do |options|
+  u3d(raw_logs: options[:raw_logs], run_args: "-logFile '/dev/stdout' -executeMethod U3d.EditorRun.Build -quit -batchmode")
+end

--- a/lib/u3d/unity_runner.rb
+++ b/lib/u3d/unity_runner.rb
@@ -59,7 +59,8 @@ module U3d
         else
           args.map!(&:shellescape)
         end
-        U3dCore::CommandExecutor.execute(command: args)
+        # FIXME return value not handled
+        U3dCore::CommandExecutor.execute(command: args, print_all: true)
       ensure
         sleep 0.5
         Thread.kill(tail_thread)

--- a/lib/u3d/unity_runner.rb
+++ b/lib/u3d/unity_runner.rb
@@ -31,7 +31,7 @@ module U3d
       log_file = find_logFile_in_args(args)
 
       if log_file # we wouldn't want to do that for the default log file.
-        File.delete(log_file) if File.exist?(log_file)
+        File.delete(log_file) if File.file?(log_file) # We only delete real files
       else
         log_file = installation.default_log_file
       end


### PR DESCRIPTION
Using -logFile /dev/stdout crashes u3d right now. This PR makes it functional. The prettifyer isn't yet plugged into it, but the output is now displayed.