### PR TITLE
Make Linux installer functional again

### DIFF
--- a/lib/u3d/installer.rb
+++ b/lib/u3d/installer.rb
@@ -92,7 +92,7 @@ module U3d
     def version
       # I don't find an easy way to extract the version on Linux
       require 'rexml/document'
-      fpath = "#{path}/Data/PlaybackEngines/LinuxStandaloneSupport/ivy.xml"
+      fpath = "#{path}/Editor/Data/PlaybackEngines/LinuxStandaloneSupport/ivy.xml"
       raise "Couldn't find file #{fpath}" unless File.exist? fpath
       doc = REXML::Document.new(File.read(fpath))
       version = REXML::XPath.first(doc, 'ivy-module/info/@e:unityVersion').value

--- a/lib/u3d/installer.rb
+++ b/lib/u3d/installer.rb
@@ -301,7 +301,7 @@ module U3d
         U3dCore::CommandExecutor.execute(command: cmd, admin: true)
       end
     rescue => e
-      UI.error "Failed to install bash file at #{file_path}: #{e}"
+      UI.error "Failed to install bash file at #{file}: #{e}"
     else
       UI.success 'Installation successful'
     end

--- a/lib/u3d/installer.rb
+++ b/lib/u3d/installer.rb
@@ -275,7 +275,7 @@ module U3d
     end
 
     def installed
-      find = File.join(DEFAULT_LINUX_INSTALL, 'Unity*')
+      find = File.join(DEFAULT_LINUX_INSTALL, 'Unity_*', 'unity-*')
       versions = Dir[find].map { |path| LinuxInstallation.new(path: path) }
 
       # sorting should take into account stable/patch etc

--- a/lib/u3d/installer.rb
+++ b/lib/u3d/installer.rb
@@ -275,7 +275,7 @@ module U3d
     end
 
     def installed
-      find = File.join(DEFAULT_LINUX_INSTALL, 'Unity_*', 'unity-*')
+      find = File.join(DEFAULT_LINUX_INSTALL, 'unity-editor-*')
       versions = Dir[find].map { |path| LinuxInstallation.new(path: path) }
 
       # sorting should take into account stable/patch etc
@@ -285,7 +285,7 @@ module U3d
     def install(file_path, version, installation_path: nil, info: {})
       extension = File.extname(file_path)
       raise "Installation of #{extension} files is not supported on Linux" if extension != '.sh'
-      path = installation_path || File.join(DEFAULT_LINUX_INSTALL, UNITY_DIR % version)
+      path = installation_path || DEFAULT_LINUX_INSTALL
       install_sh(
         file_path,
         installation_path: path

--- a/lib/u3d/installer.rb
+++ b/lib/u3d/installer.rb
@@ -295,8 +295,11 @@ module U3d
     def install_sh(file, installation_path: nil)
       cmd = file.shellescape
       if installation_path
-        Utils.ensure_dir(installation_path)
-        U3dCore::CommandExecutor.execute(command: "cd #{installation_path}; #{cmd}", admin: true)
+        command = "cd \"#{installation_path}\"; #{cmd}"
+        unless File.directory? installation_path
+          command = "mkdir -p \"#{installation_path}\"; #{command}"
+        end
+        U3dCore::CommandExecutor.execute(command: command, admin: true)
       else
         U3dCore::CommandExecutor.execute(command: cmd, admin: true)
       end

--- a/lib/u3d_core/command_executor.rb
+++ b/lib/u3d_core/command_executor.rb
@@ -73,7 +73,7 @@ module U3dCore
           if Helper.windows?
             raise CredentialsError, "The command \'#{command}\' must be run in administrative shell" unless has_admin_privileges?
           else
-            command = "sudo -k && echo #{cred.password.shellescape} | sudo -S " + command
+            command = "sudo -k && echo #{cred.password.shellescape} | sudo -S bash -c \"#{command}\""
           end
           UI.verbose 'Admin privileges granted for command execution'
         end


### PR DESCRIPTION
there are 4 at least problems right now.

3 under install
* one small typo in variable name (fixed)
* one where command executor doesn't like when 2 commands are passed (cd /dir; something)
* one where mkdir fails because of lack of privileges. We could detect if we need sudo to create repo by doing `touch -d /opt/` and test for result

Really not sure why so many issues. It looks like this was implemented in an environment where root was already there

and then even if I manage to install, `u3d list` doesn't work as expected

````
$ u3d list
error: Couldn't find file /opt/Unity_2017.2.0b2/Data/PlaybackEngines/LinuxStandaloneSupport/ivy.xml. Use --trace to view backtrace
````

it should be searching under `/opt/Unity_2017.2.0b2/unity-editor-2017.2.0b2/Editor/Data/PlaybackEngines/LinuxStandaloneSupport/ivy.xml`

this may have broke because of newer versions of the installer