### PR TITLE
Fix corrupted file on Linux

### DIFF
--- a/lib/u3d/downloader.rb
+++ b/lib/u3d/downloader.rb
@@ -268,13 +268,8 @@ module U3d
           file_name = UNITY_MODULE_FILE_REGEX.match(url)[1]
           file_path = File.expand_path(file_name, dir)
 
-          # Assume size from online ressource
-          uri = URI(url)
-          size = nil
-          Net::HTTP.start(uri.host, uri.port) do |http|
-            response = http.request_head url
-            size = Integer(response['Content-Length'])
-          end
+          ini_file = INIparser.load_ini(version, [], os: :linux)
+          size = ini_file['size'] if ini_file
           # Check if file already exists
           # Note: without size or hash validation, the file is assumed to be correct
           if File.file?(file_path)

--- a/lib/u3d/downloader.rb
+++ b/lib/u3d/downloader.rb
@@ -268,11 +268,11 @@ module U3d
           file_name = UNITY_MODULE_FILE_REGEX.match(url)[1]
           file_path = File.expand_path(file_name, dir)
 
-          ini_file = INIparser.load_ini(version, [], os: :linux)
-          size = ini_file['size'] if ini_file
           # Check if file already exists
           # Note: without size or hash validation, the file is assumed to be correct
           if File.file?(file_path)
+            ini_file = INIparser.load_ini(version, [], os: :linux)
+            size = ini_file['size'] if ini_file
             if size
               if File.size(file_path) != size
                 UI.important "File at #{file_path} is corrupted, deleting it"

--- a/lib/u3d/iniparser.rb
+++ b/lib/u3d/iniparser.rb
@@ -66,6 +66,17 @@ module U3d
         result
       end
 
+      def create_linux_ini(version, size)
+        ini_name = INI_NAME % { version: version, os: 'linux' }
+        Utils.ensure_dir(default_ini_path)
+        ini_path = File.expand_path(ini_name, default_ini_path)
+        unless File.file?(ini_path)
+          File.open(ini_path, 'wb') do |f|
+            f.write "[Unity]\ntitle=Unity\nsize=#{size}"
+          end
+        end
+      end
+
       private
 
       def default_ini_path

--- a/lib/u3d/iniparser.rb
+++ b/lib/u3d/iniparser.rb
@@ -68,12 +68,12 @@ module U3d
       end
 
       def create_linux_ini(version, size)
-        ini_name = INI_NAME % { version: version, os: 'linux' }
+        ini_name = format(INI_NAME, version: version, os: 'linux')
         Utils.ensure_dir(default_ini_path)
         ini_path = File.expand_path(ini_name, default_ini_path)
-        unless File.file?(ini_path)
-          File.open(ini_path, 'wb') do |f|
-            f.write %Q([Unity]
+        return if File.file? ini_path
+        File.open(ini_path, 'wb') do |f|
+          f.write %([Unity]
 ; -- NOTE --
 ; This is not an official Unity file
 ; This has been created by u3d
@@ -81,7 +81,6 @@ module U3d
 title=Unity
 size=#{size}
 )
-          end
         end
       end
 

--- a/lib/u3d/iniparser.rb
+++ b/lib/u3d/iniparser.rb
@@ -37,9 +37,6 @@ module U3d
 
     class << self
       def load_ini(version, cached_versions, os: U3dCore::Helper.operating_system, offline: false)
-        unless %i[win mac].include? os
-          raise ArgumentError, "OS #{os.id2name} does not use ini files"
-        end
         os = if os == :mac
                'osx'
              else
@@ -49,6 +46,10 @@ module U3d
         Utils.ensure_dir(default_ini_path)
         ini_path = File.expand_path(ini_name, default_ini_path)
         unless File.file?(ini_path)
+          if os == 'linux'
+            UI.error "No INI file for version #{version}"
+            return nil
+          end
           raise "INI file does not exist at #{ini_path}" if offline
           uri = URI(cached_versions[version] + ini_name)
           File.open(ini_path, 'wb') do |f|

--- a/lib/u3d/iniparser.rb
+++ b/lib/u3d/iniparser.rb
@@ -47,7 +47,7 @@ module U3d
         ini_path = File.expand_path(ini_name, default_ini_path)
         unless File.file?(ini_path)
           if os == 'linux'
-            UI.error "No INI file for version #{version}"
+            UI.error "No INI file for version #{version}. Try discovering the available versions with 'u3d available -f'"
             return nil
           end
           raise "INI file does not exist at #{ini_path}" if offline
@@ -73,7 +73,14 @@ module U3d
         ini_path = File.expand_path(ini_name, default_ini_path)
         unless File.file?(ini_path)
           File.open(ini_path, 'wb') do |f|
-            f.write "[Unity]\ntitle=Unity\nsize=#{size}"
+            f.write %Q([Unity]
+; -- NOTE --
+; This is not an official Unity file
+; This has been created by u3d
+; ----------
+title=Unity
+size=#{size}
+)
           end
         end
       end

--- a/lib/u3d/unity_versions.rb
+++ b/lib/u3d/unity_versions.rb
@@ -94,7 +94,6 @@ module U3d
 
           data = linux_forum_page_content
 
-          data.gsub(/[ \t]+/, '').each_line { |l| puts l if /<a href=/ =~ l }
           versions = {}
           results = data.scan(LINUX_DOWNLOAD_DATED)
           results.each do |capt|
@@ -105,12 +104,7 @@ module U3d
           response = nil
           results = data.scan(LINUX_DOWNLOAD_RECENT_PAGE)
           results.each do |page|
-            url = page[0]
-            uri = URI(url)
-            Net::HTTP.start(uri.host, uri.port) do |http|
-              request = Net::HTTP::Get.new uri
-              response = http.request request
-            end
+            response = linux_forum_version_page_content(page[0])
             if response.is_a? Net::HTTPSuccess
               capt = response.body.match(LINUX_DOWNLOAD_RECENT_FILE)
               if capt && capt[1] && capt[2]
@@ -205,6 +199,14 @@ module U3d
             end
           end
           data
+        end
+
+        def linux_forum_version_page_content(url)
+          uri = URI(url)
+          Net::HTTP.start(uri.host, uri.port) do |http|
+            request = Net::HTTP::Get.new uri
+            return http.request request
+          end
         end
       end
     end

--- a/lib/u3d/unity_versions.rb
+++ b/lib/u3d/unity_versions.rb
@@ -115,6 +115,7 @@ module U3d
               capt = response.body.match(LINUX_DOWNLOAD_RECENT_FILE)
               if capt && capt[1] && capt[2]
                 ver = capt[2].delete('x')
+                UI.important "Version #{ver} does not match standard Unity versions" unless ver =~ Utils::UNITY_VERSION_REGEX
                 save_package_size(ver, capt[1])
                 versions[ver] = capt[1]
               else
@@ -139,7 +140,11 @@ module U3d
             response = http.request_head url
             size = Integer(response['Content-Length'])
           end
-          INIparser.create_linux_ini(version, size) if size
+          if size
+            INIparser.create_linux_ini(version, size)
+          else
+            UI.important "u3d tried to get the size of the installer for version #{version}, but wasn't able to"
+          end
         end
 
         def linux_forum_page_content

--- a/spec/u3d/iniparser_spec.rb
+++ b/spec/u3d/iniparser_spec.rb
@@ -33,10 +33,6 @@ describe U3d do
         @path = File.expand_path(name, "#{ENV['HOME']}/.u3d/ini_files")
       end
 
-      it 'raises an error when trying to load INI files for OS different from Mac or Windows' do
-        expect { U3d::INIparser.load_ini('key', @cache, os: :linux) }.to raise_error(ArgumentError)
-      end
-
       context 'when offline' do
         # this to ensure tests are not failing on Linux platform
         let(:platform_os) { :mac }


### PR DESCRIPTION
See #21 for the issue.

Fixes the issue by checking if the size of the file that is present is correct. Unlike under Windows or Mac, where the size is checkable in the .ini files, Linux doesn't uses ini files and therefore must rely on checking the expected size of the file online. As this can lead to a failure for some reason, if the file size cannot be verified, then the file is assumed correct.