### PR TITLE
u3d/dependencies: add command to install Linux dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ The prettifyer is on by default but can be turned off to get Unity3d's raw outpu
 
   [Information on how `prettify` works](https://github.com/DragonBox/u3d/blob/master/LOG_RULES.md)
 
+* `u3d dependencies`: [Linux] Install dependencies that Unity don't install by default on Linux.
+
 ## Installation
 
 ```shell

--- a/lib/u3d/commands.rb
+++ b/lib/u3d/commands.rb
@@ -129,13 +129,13 @@ module U3d
         Installer.install_modules(files, definition.version, installation_path: options[:installation_path])
       end
 
-      def install_dependencies(options: {})
+      def install_dependencies
         unless Helper.linux?
           UI.important 'u3d dependencies is Linux-only, and not needed on other OS'
           return
         end
 
-        LinuxDependencies.install(prefix: options[:package_manager])
+        LinuxDependencies.install
       end
 
       def run(options: {}, run_args: [])

--- a/lib/u3d/commands.rb
+++ b/lib/u3d/commands.rb
@@ -129,6 +129,15 @@ module U3d
         Installer.install_modules(files, definition.version, installation_path: options[:installation_path])
       end
 
+      def install_linux_dependencies(options: {})
+        unless Helper.linux?
+          UI.important 'u3d dependencies is Linux-only, and not needed on other OS'
+          return
+        end
+
+        LinuxDependencies.install(prefix: options[:package_manager])
+      end
+
       def run(options: {}, run_args: [])
         version = options[:unity_version]
 

--- a/lib/u3d/commands.rb
+++ b/lib/u3d/commands.rb
@@ -129,7 +129,7 @@ module U3d
         Installer.install_modules(files, definition.version, installation_path: options[:installation_path])
       end
 
-      def install_linux_dependencies(options: {})
+      def install_dependencies(options: {})
         unless Helper.linux?
           UI.important 'u3d dependencies is Linux-only, and not needed on other OS'
           return

--- a/lib/u3d/commands_generator.rb
+++ b/lib/u3d/commands_generator.rb
@@ -164,7 +164,7 @@ More on that: https://forum.unity3d.com/threads/unity-on-linux-release-notes-and
                   )
         c.option '-p', '--package_manager STRING', String, 'Specify which package manager to use (apt-get, yum...)'
         c.action do |_args, options|
-          Commands.install_linux_dependencies(options: convert_options(options))
+          Commands.install_dependencies(options: convert_options(options))
         end
       end
 

--- a/lib/u3d/commands_generator.rb
+++ b/lib/u3d/commands_generator.rb
@@ -148,6 +148,15 @@ This command allows you to either:
         end
       end
 
+      command :dependencies do |c|
+        c.syntax = 'u3d dependencies [-p | --package_manager <package manager>]'
+        c.description = 'Installs Unity dependencies. [Linux only]'
+        c.option '-p', '--package_manager STRING', String, 'Specify which package manager to use (aptitude, rpm...)'
+        c.action do |_args, options|
+          Commands.install_linux_dependencies(options: convert_options(options))
+        end
+      end
+
       command :credentials do |c|
         c.syntax = "u3d credentials <#{Commands.credentials_actions.join(' | ')}>"
         c.description = 'Manages keychain credentials so u3d remembers them. [OSX only]'

--- a/lib/u3d/commands_generator.rb
+++ b/lib/u3d/commands_generator.rb
@@ -150,8 +150,19 @@ This command allows you to either:
 
       command :dependencies do |c|
         c.syntax = 'u3d dependencies [-p | --package_manager <package manager>]'
-        c.description = 'Installs Unity dependencies. [Linux only]'
-        c.option '-p', '--package_manager STRING', String, 'Specify which package manager to use (aptitude, rpm...)'
+        c.summary = 'Installs Unity dependencies. [Linux only]'
+        c.description = %(
+#{c.summary}
+
+Regarding the package manager: if none is specified, u3d will try to assume it by testing which one.s is.are installed.
+Only apt-get and yum are tested right now.
+
+If several package manager are installed on your machine simultaneously, we recommend that you specify the one you want to use.
+
+Regarding the dependencies themselves: only dependencies for the editor are installed. WebGL, Android and Tizen require others that you will have to install manually.
+More on that: https://forum.unity3d.com/threads/unity-on-linux-release-notes-and-known-issues.350256/
+                  )
+        c.option '-p', '--package_manager STRING', String, 'Specify which package manager to use (apt-get, yum...)'
         c.action do |_args, options|
           Commands.install_linux_dependencies(options: convert_options(options))
         end

--- a/lib/u3d/commands_generator.rb
+++ b/lib/u3d/commands_generator.rb
@@ -154,17 +154,14 @@ This command allows you to either:
         c.description = %(
 #{c.summary}
 
-Regarding the package manager: if none is specified, u3d will try to assume it by testing which one.s is.are installed.
-Only apt-get and yum are tested right now.
-
-If several package managers are installed on your machine simultaneously, we recommend that you specify the one you want to use.
+Regarding the package manager: if dpkg is installed, u3d uses apt-get else if rpm is installed yum is used. If none of them is insalled, fails.
 
 Regarding the dependencies themselves: only dependencies for the editor are installed. WebGL, Android and Tizen require others that you will have to install manually.
 More on that: https://forum.unity3d.com/threads/unity-on-linux-release-notes-and-known-issues.350256/
                   )
         c.option '-p', '--package_manager STRING', String, 'Specify which package manager to use (apt-get, yum...)'
-        c.action do |_args, options|
-          Commands.install_dependencies(options: convert_options(options))
+        c.action do |_args, _options|
+          Commands.install_dependencies
         end
       end
 

--- a/lib/u3d/commands_generator.rb
+++ b/lib/u3d/commands_generator.rb
@@ -157,7 +157,7 @@ This command allows you to either:
 Regarding the package manager: if none is specified, u3d will try to assume it by testing which one.s is.are installed.
 Only apt-get and yum are tested right now.
 
-If several package manager are installed on your machine simultaneously, we recommend that you specify the one you want to use.
+If several package managers are installed on your machine simultaneously, we recommend that you specify the one you want to use.
 
 Regarding the dependencies themselves: only dependencies for the editor are installed. WebGL, Android and Tizen require others that you will have to install manually.
 More on that: https://forum.unity3d.com/threads/unity-on-linux-release-notes-and-known-issues.350256/

--- a/lib/u3d/commands_generator.rb
+++ b/lib/u3d/commands_generator.rb
@@ -149,7 +149,7 @@ This command allows you to either:
       end
 
       command :dependencies do |c|
-        c.syntax = 'u3d dependencies [-p | --package_manager <package manager>]'
+        c.syntax = 'u3d dependencies'
         c.summary = 'Installs Unity dependencies. [Linux only]'
         c.description = %(
 #{c.summary}
@@ -159,7 +159,6 @@ Regarding the package manager: if dpkg is installed, u3d uses apt-get else if rp
 Regarding the dependencies themselves: only dependencies for the editor are installed. WebGL, Android and Tizen require others that you will have to install manually.
 More on that: https://forum.unity3d.com/threads/unity-on-linux-release-notes-and-known-issues.350256/
                   )
-        c.option '-p', '--package_manager STRING', String, 'Specify which package manager to use (apt-get, yum...)'
         c.action do |_args, _options|
           Commands.install_dependencies
         end

--- a/lib/u3d/installer.rb
+++ b/lib/u3d/installer.rb
@@ -323,13 +323,15 @@ module U3d
       'libpq5' # missing from original list
     ].freeze
 
-    def self.install
-      if `which dpkg` != ''
-        prefix = 'apt-get -y install'
-      elsif `which rpm` != ''
-        prefix = 'yum -y install'
-      else
-        raise 'Cannot install dependencies on your Linux distribution'
+    def self.install(prefix: nil)
+      unless prefix
+        if `which dpkg` != ''
+          prefix = 'apt-get -y install'
+        elsif `which rpm` != ''
+          prefix = 'yum -y install'
+        else
+          raise 'Cannot install dependencies on your Linux distribution'
+        end
       end
       if UI.interactive?
         return unless UI.confirm "Install dependencies? (#{DEPENDENCIES.length} dependency(ies) to install)"

--- a/lib/u3d/installer.rb
+++ b/lib/u3d/installer.rb
@@ -279,4 +279,62 @@ module U3d
       end
     end
   end
+
+  class LinuxDependencies
+    # see https://forum.unity3d.com/threads/unity-on-linux-release-notes-and-known-issues.350256/
+    DEPENDENCIES = [
+      'gconf-service',
+      'lib32gcc1',
+      'lib32stdc++6',
+      'libasound2',
+      'libc6',
+      'libc6-i386',
+      'libcairo2',
+      'libcap2',
+      'libcups2',
+      'libdbus-1-3',
+      'libexpat1',
+      'libfontconfig1',
+      'libfreetype6',
+      'libgcc1',
+      'libgconf-2-4',
+      'libgdk-pixbuf2.0-0',
+      'libgl1-mesa-glx',
+      'libglib2.0-0',
+      'libglu1-mesa',
+      'libgtk2.0-0',
+      'libnspr4',
+      'libnss3',
+      'libpango1.0-0',
+      'libstdc++6',
+      'libx11-6',
+      'libxcomposite1',
+      'libxcursor1',
+      'libxdamage1',
+      'libxext6',
+      'libxfixes3',
+      'libxi6',
+      'libxrandr2',
+      'libxrender1',
+      'libxtst6',
+      'zlib1g',
+      'debconf',
+      'npm',
+      'libpq5' # missing from original list
+    ].freeze
+
+    def self.install
+      if `which dpkg` != ''
+        prefix = 'apt-get -y install'
+      elsif `which rpm` != ''
+        prefix = 'yum -y install'
+      else
+        raise 'Cannot install dependencies on your Linux distribution'
+      end
+      if UI.interactive?
+        return unless UI.confirm "Install dependencies? (#{DEPENDENCIES.length} dependency(ies) to install)"
+      end
+      U3dCore::CommandExecutor.execute(command: "#{prefix} #{DEPENDENCIES.join(' ')}", admin: true)
+    end
+  end
 end

--- a/lib/u3d/installer.rb
+++ b/lib/u3d/installer.rb
@@ -323,16 +323,15 @@ module U3d
       'libpq5' # missing from original list
     ].freeze
 
-    def self.install(prefix: nil)
-      unless prefix
-        if `which dpkg` != ''
-          prefix = 'apt-get -y install'
-        elsif `which rpm` != ''
-          prefix = 'yum -y install'
-        else
-          raise 'Cannot install dependencies on your Linux distribution'
-        end
+    def self.install
+      if `which dpkg` != ''
+        prefix = 'apt-get -y install'
+      elsif `which rpm` != ''
+        prefix = 'yum -y install'
+      else
+        raise 'Cannot install dependencies on your Linux distribution'
       end
+
       if UI.interactive?
         return unless UI.confirm "Install dependencies? (#{DEPENDENCIES.length} dependency(ies) to install)"
       end


### PR DESCRIPTION
Before installing Unity on Linux, the installer will now install its required dependencies.