### PR TITLE
Fix Linux runner and installation

### DIFF
--- a/lib/u3d/installer.rb
+++ b/lib/u3d/installer.rb
@@ -107,7 +107,7 @@ module U3d
     end
 
     def exe_path
-      "#{path}/Unity"
+      "#{path}/Editor/Unity"
     end
 
     def packages
@@ -384,7 +384,9 @@ module U3d
     def editor_version
       require 'yaml'
       yaml = YAML.load(File.read("#{@path}/ProjectSettings/ProjectVersion.txt"))
-      yaml['m_EditorVersion']
+      version = yaml['m_EditorVersion']
+      version.gsub!(/(\d+\.\d+\.\d+)(?:x)?(\w\d+)(?:Linux)?/, '\1\2') if Helper.linux?
+      version
     end
   end
 end

--- a/lib/u3d/unity_runner.rb
+++ b/lib/u3d/unity_runner.rb
@@ -36,6 +36,7 @@ module U3d
         log_file = installation.default_log_file
       end
 
+      Utils.ensure_dir File.dirname(log_file)
       FileUtils.touch(log_file) unless File.exist? log_file
 
       tail_thread = Thread.new do
@@ -63,7 +64,7 @@ module U3d
         else
           args.map!(&:shellescape)
         end
-        # FIXME return value not handled
+        
         U3dCore::CommandExecutor.execute(command: args, print_all: true)
       ensure
         sleep 1


### PR DESCRIPTION
* Runner now makes sure that the directory containing the log exists
before attempting to create it.

* The UnityProject now parses correctly its version under Linux

* LinuxInstallation uses the correct path for the exe