### PR TITLE
[linux] Adjust to weird editor versions stored under ProjectSettings/ProjectVersion.txt

### DIFF
--- a/lib/u3d/installer.rb
+++ b/lib/u3d/installer.rb
@@ -398,7 +398,9 @@ module U3d
     def editor_version
       require 'yaml'
       yaml = YAML.load(File.read("#{@path}/ProjectSettings/ProjectVersion.txt"))
-      yaml['m_EditorVersion']
+      version = yaml['m_EditorVersion']
+      version.gsub!(/(\d+\.\d+\.\d+)(?:x)?(\w\d+)(?:Linux)?/, '\1\2') if Helper.linux?
+      version
     end
   end
 end

--- a/lib/u3d/unity_runner.rb
+++ b/lib/u3d/unity_runner.rb
@@ -64,7 +64,7 @@ module U3d
         else
           args.map!(&:shellescape)
         end
-        # FIXME return value not handled
+        
         U3dCore::CommandExecutor.execute(command: args, print_all: true)
       ensure
         sleep 1

--- a/spec/u3d/unity_project_spec.rb
+++ b/spec/u3d/unity_project_spec.rb
@@ -1,0 +1,61 @@
+require 'u3d/installer'
+require 'u3d_core/helper'
+require 'yaml'
+
+describe U3d do
+  describe U3d::UnityProject do
+    describe '#editor_version' do
+      before(:all) do
+        @config = { 'm_EditorVersion' => 'test' }
+        @project = U3d::UnityProject.new('foo')
+      end
+
+      before(:each) do
+        allow(File).to receive(:read) { 'bar' }
+        allow(YAML).to receive(:load) { @config }
+      end
+
+      describe 'when under Linux' do
+        before(:each) do
+          allow(U3d::Helper).to receive(:linux?) { true }
+        end
+
+        it 'leaves correct versions untouched' do
+          @config = { 'm_EditorVersion' => '5.6.0f3' }
+          expect(@project.editor_version).to eql('5.6.0f3')
+        end
+
+        it 'cleans versions that should be' do
+          @config = { 'm_EditorVersion' => '2017.1.0xf3Linux' }
+          expect(@project.editor_version).to eql('2017.1.0f3')
+        end
+
+        it 'does not change unrecognized versions' do
+          @config = { 'm_EditorVersion' => 'very.special.version' }
+          expect(@project.editor_version).to eql('very.special.version')
+        end
+      end
+
+      describe 'when not under Linux' do
+        before(:each) do
+          allow(U3d::Helper).to receive(:linux?) { false }
+        end
+
+        it 'leaves correct versions untouched' do
+          @config = { 'm_EditorVersion' => '5.6.0f3' }
+          expect(@project.editor_version).to eql('5.6.0f3')
+        end
+
+        it 'does not act on Linux unclean versions' do
+          @config = { 'm_EditorVersion' => '2017.1.0xf3Linux' }
+          expect(@project.editor_version).to eql('2017.1.0xf3Linux')
+        end
+
+        it 'does not change unrecognized versions' do
+          @config = { 'm_EditorVersion' => 'very.special.version' }
+          expect(@project.editor_version).to eql('very.special.version')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
The YAML configuration file of a Unity project may often refer to weird Linux versions such as '2017.1.0xf3Linux'. To be sure that this is recognized by u3d, we parse this type of version (so in this example it would be '2017.1.0f3').

Comes with spec to make sure it works as intended.