### PR TITLE
u3d/install: do not try to download unknown versions (i.e. not in cache)

### DIFF
--- a/lib/u3d/commands.rb
+++ b/lib/u3d/commands.rb
@@ -105,6 +105,10 @@ module U3d
 
         cache = Cache.new(force_os: os)
         versions = cache[os.id2name]['versions']
+        unless versions[version]
+          UI.error "No version #{version} was found in cache"
+          return
+        end
         version = interpret_latest(version, versions)
 
         unity = check_unity_presence(version: version)

--- a/lib/u3d/commands.rb
+++ b/lib/u3d/commands.rb
@@ -107,7 +107,7 @@ module U3d
         versions = cache[os.id2name]['versions']
         version = interpret_latest(version, versions)
         unless versions[version]
-          UI.error "No version #{version} was found in cache"
+          UI.error "No version #{version} was found in cache. Either it doesn't exist or u3d doesn't know about it yet. Try refreshing with 'u3d available -f'"
           return
         end
 

--- a/lib/u3d/commands.rb
+++ b/lib/u3d/commands.rb
@@ -105,11 +105,11 @@ module U3d
 
         cache = Cache.new(force_os: os)
         versions = cache[os.id2name]['versions']
+        version = interpret_latest(version, versions)
         unless versions[version]
           UI.error "No version #{version} was found in cache"
           return
         end
-        version = interpret_latest(version, versions)
 
         unity = check_unity_presence(version: version)
         return unless enforce_setup_coherence(packages, options, unity)


### PR DESCRIPTION
u3d was going pretty far in the download process before realizing the version was not in the cache, and returning. It returns now way earlier.