### PR TITLE
Mac Installer fix

### DIFF
--- a/lib/u3d/installer.rb
+++ b/lib/u3d/installer.rb
@@ -137,7 +137,6 @@ module U3d
         UI.verbose "No Unity install for version #{version} was found"
         U3dCore::CommandExecutor.execute(command: command, admin: true)
         destination_path = File.join(target_path, 'Applications', UNITY_DIR % version)
-        Utils.ensure_dir destination_path
         FileUtils.mv temp_path, destination_path
       else
         begin

--- a/lib/u3d/installer.rb
+++ b/lib/u3d/installer.rb
@@ -132,13 +132,16 @@ module U3d
       target_path ||= DEFAULT_MAC_INSTALL
       command = "installer -pkg #{file_path.shellescape} -target #{target_path.shellescape}"
       unity = installed.find { |u| u.version == version }
+      temp_path = File.join(target_path, 'Applications', 'Unity')
       if unity.nil?
         UI.verbose "No Unity install for version #{version} was found"
         U3dCore::CommandExecutor.execute(command: command, admin: true)
+        destination_path = File.join(target_path, 'Applications', UNITY_DIR % version)
+        Utils.ensure_dir destination_path
+        FileUtils.mv temp_path, destination_path
       else
         begin
           path = File.expand_path('..', unity.path)
-          temp_path = File.join(target_path, 'Applications', 'Unity')
           move_to_temp = (temp_path != path)
           if move_to_temp
             UI.verbose "Temporary switching location of #{path} to #{temp_path} for installation purpose"


### PR DESCRIPTION
This fix makes sure that we move new Unity installs under our correct format (ie Unity_0.0.0x0) for fresh installs.

This should fix #68, and this being fixed would fix #71