### PR TITLE
u3d/install: move chmod +x of linux files at install time (Fixes #91)

### DIFF
--- a/lib/u3d/downloader.rb
+++ b/lib/u3d/downloader.rb
@@ -53,11 +53,6 @@ module U3d
         packages.each do |package|
           get_package(downloader, validator, package, definition, files)
         end
-
-        # On Linux, make sure the files are executable
-        # FIXME: Move me to the LinuxInstaller
-        files.each { |f| U3dCore::CommandExecutor.execute(command: "chmod a+x #{f[1]}") } if definition.os == :linux
-
         files
       end
 

--- a/lib/u3d/installer.rb
+++ b/lib/u3d/installer.rb
@@ -197,10 +197,13 @@ module U3d
 
     def install_sh(file, installation_path: nil)
       cmd = file.shellescape
+
+      U3dCore::CommandExecutor.execute(command: "chmod a+x #{cmd}")
+
       if installation_path
-        command = "cd \"#{installation_path}\"; #{cmd}"
+        command = "cd #{installation_path.shellescape}; #{cmd}"
         unless File.directory? installation_path
-          command = "mkdir -p \"#{installation_path}\"; #{command}"
+          command = "mkdir -p #{installation_path.shellescape}; #{command}"
         end
         U3dCore::CommandExecutor.execute(command: command, admin: true)
       else

--- a/spec/u3d/downloader_spec.rb
+++ b/spec/u3d/downloader_spec.rb
@@ -63,7 +63,6 @@ describe U3d do
           allow(U3d::Downloader).to receive(:get_package).with(anything, anything, 'packageA', @definition, anything).and_wrap_original do |_m, *args|
             args[4] << ['packageA', 'filepath', {}]
           end
-          expect(U3dCore::CommandExecutor).to receive(:execute).with(command: 'chmod a+x filepath') {}
 
           U3d::Downloader.download_modules(@definition, packages: ['packageA'])
         end

--- a/spec/u3d/installer_spec.rb
+++ b/spec/u3d/installer_spec.rb
@@ -119,6 +119,20 @@ describe U3d do
           U3d::LinuxInstaller.new.sanitize_install(unity)
         end
       end
+
+      describe '.install' do
+        it 'installs a file in standard installation path' do
+          filepath = "file.sh"
+          allow(File).to receive(:directory?).with(U3d::DEFAULT_LINUX_INSTALL) { true }
+          expect(U3dCore::CommandExecutor).to receive(:execute).with(command: 'chmod a+x file.sh') {}
+          expect(U3dCore::CommandExecutor).to receive(:execute).with(command: "cd #{U3d::DEFAULT_LINUX_INSTALL}; file.sh", admin: true) {}
+
+          installer = U3d::LinuxInstaller.new
+          expect(installer).to receive(:sanitize_install).with(anything)
+
+          installer.install(filepath, '1.2.3f4', installation_path: nil)
+        end
+      end
     end
 
     xdescribe U3d::WindowsInstaller do


### PR DESCRIPTION
Note that I've moved to use shellescape in Linux installer. We should quickly test it.