### PR TITLE
Fix INIT log phase not starting when intended

### DIFF
--- a/config/log_rules.json
+++ b/config/log_rules.json
@@ -118,7 +118,7 @@
     "active": true,
     "silent": false,
     "comment": "Initialization on editor launch",
-    "phase_start_pattern": "Initialize mono",
+    "phase_start_pattern": "(?:COMMAND LINE|Initialize mono)",
     "rules": {
       "mono_options": {
         "active": true,


### PR DESCRIPTION
The order of the logs has changed from Unity5+ to Unity2017+ and the INIT
log phase was not starting as intended. This adds an alternative
entrypoint for the phase to match 2017 ordering.

Fixes #99 