### PR TITLE
ud3/prettifier exception rule improvements

### DIFF
--- a/config/log_rules.json
+++ b/config/log_rules.json
@@ -24,10 +24,10 @@
       },
       "exception": {
         "active": true,
-        "start_pattern": "[eE]xception.*: (?<message>.*)\\n",
-        "end_pattern": "Filename: (?:[\\w/:]+/(?<file>\\w+\\.\\w+))? Line: (?<line>-?\\d+)",
+        "start_pattern": "[eE]xception\\w*: (?<message>.*)\\n",
+        "end_pattern": "(?:Filename: (?:[\\w/:]+/(?<file>\\w+\\.\\w+))? Line: (?<line>-?\\d+)|(?<fileunknown>filename unknown)>:(?<lineunknown>-?\\d+))",
         "start_message": false,
-        "end_message": "%{file}(line %{line}): %{message}",
+        "end_message": "%{file}%{fileunknown}(line %{line}%{lineunknown}): %{message}",
         "store_lines": false,
         "ignore_lines": [
           "UnityEditor",


### PR DESCRIPTION
- Restrict rule start to actual exceptions and prevent it from firing on other log with exceptions (for instance on updating/loading/building custom exception classes).

-  Adds alternative end condition to exception rule when the file that raised the exception is unknown (ThreadAbortException for example).