### PR TITLE
u3d/prettify: modify compiler rule parsing for 2017+

### DIFF
--- a/config/log_rules.json
+++ b/config/log_rules.json
@@ -185,13 +185,13 @@
     "active": true,
     "silent": false,
     "comment": "Compiling phase",
-    "phase_start_pattern": "- starting compile",
+    "phase_start_pattern": "- [sS]tarting compile",
     "phase_end_pattern": "- Finished compile",
     "rules": {
       "target": {
         "active": true,
-        "start_pattern": "- starting compile (?<path>.+), for buildtarget (?<target>.+)",
-        "start_message": "Target: %{path} (buildtarget %{target})"
+        "start_pattern": "- [sS]tarting compile (?<path>.+)(?<target>, for buildtarget .+)?",
+        "start_message": "Starting compile: %{path} %{target}"
       },
       "finished": {
         "active": true,

--- a/lib/u3d/log_analyzer.rb
+++ b/lib/u3d/log_analyzer.rb
@@ -108,6 +108,7 @@ module U3d
               message = "[#{header}] " + message
               UI.send(rule['type'], message)
             end
+            UI.verbose("--- Ending #{@active_rule} rule ---")
             @active_rule = nil
             @context.clear
             @rule_lines_buffer.clear
@@ -132,7 +133,12 @@ module U3d
           ruleset.each do |rn, r|
             pattern = r['start_pattern']
             next unless line =~ pattern
-            @active_rule = rn if r['end_pattern']
+            if r['end_pattern']
+              @active_rule = rn
+              UI.verbose("--- Beginning #{rn} rule ---")
+            else
+              UI.verbose("--- One line rule #{rn} ---")
+            end
             match = line.match(pattern)
             @context = match.names.map(&:to_sym).zip(match.captures).to_h
             if r['fetch_line_at_index'] || r['fetch_first_line_not_matching']
@@ -185,7 +191,6 @@ module U3d
       if @active_phase
         apply_ruleset.call(@phases[@active_phase]['rules'], @active_phase)
         if @phases[@active_phase]['phase_end_pattern'] && @phases[@active_phase]['phase_end_pattern'] =~ line
-          UI.verbose("--- Ending #{@active_phase} phase ---")
           finish_phase
         end
       end
@@ -201,6 +206,7 @@ module U3d
         UI.error("[#{@active_phase}] Could not finish active rule '#{@active_rule}'. Aborting it.")
         @active_rule = nil
       end
+      UI.verbose("--- Ending #{@active_phase} phase ---")
       @active_phase = nil
       @context.clear
       @rule_lines_buffer.clear

--- a/lib/u3d/log_analyzer.rb
+++ b/lib/u3d/log_analyzer.rb
@@ -108,7 +108,6 @@ module U3d
               message = "[#{header}] " + message
               UI.send(rule['type'], message)
             end
-            UI.verbose("--- Ending #{@active_rule} rule ---")
             @active_rule = nil
             @context.clear
             @rule_lines_buffer.clear
@@ -133,12 +132,7 @@ module U3d
           ruleset.each do |rn, r|
             pattern = r['start_pattern']
             next unless line =~ pattern
-            if r['end_pattern']
-              @active_rule = rn
-              UI.verbose("--- Beginning #{rn} rule ---")
-            else
-              UI.verbose("--- One line rule #{rn} ---")
-            end
+            @active_rule = rn if r['end_pattern']
             match = line.match(pattern)
             @context = match.names.map(&:to_sym).zip(match.captures).to_h
             if r['fetch_line_at_index'] || r['fetch_first_line_not_matching']


### PR DESCRIPTION
- Modifies some of the compiler rules to match the behaviour of the newer
  versions of Unity3d.

- Makes sure that the compiler phase finishes to avoid duplicated
  messages.