### PR TITLE
u3d/prettify: also plug log analyzer on stdout (Fixes #18 #43)

### DIFF
--- a/lib/u3d/unity_runner.rb
+++ b/lib/u3d/unity_runner.rb
@@ -57,7 +57,11 @@ module U3d
           args.map!(&:shellescape)
         end
 
-        U3dCore::CommandExecutor.execute(command: args, print_all: true)
+        output_callback = Proc.new do |line|
+          UI.command_output(line)
+        end
+
+        U3dCore::CommandExecutor.execute_command(command: args, output_callback: output_callback)
       ensure
         sleep 1
         Thread.kill(tail_thread)

--- a/lib/u3d/unity_runner.rb
+++ b/lib/u3d/unity_runner.rb
@@ -32,7 +32,7 @@ module U3d
 
       if raw_logs
         output_callback = proc do |line|
-          UI.message(line.rstrip)
+          UI.command_output(line.rstrip)
         end
       else
         analyzer = LogAnalyzer.new

--- a/lib/u3d_core/command_executor.rb
+++ b/lib/u3d_core/command_executor.rb
@@ -101,7 +101,7 @@ module U3dCore
               line = l.strip # strip so that \n gets removed
               output << line
 
-              output_callback.call(line) if output_callback
+              output_callback.call(l) if output_callback
             end
           end
           raise "Exit status: #{status}".red if !status.nil? && status.nonzero?

--- a/lib/u3d_core/command_executor.rb
+++ b/lib/u3d_core/command_executor.rb
@@ -57,7 +57,7 @@ module U3dCore
       # @return [String] All the output as string
       # @deprecated
       def execute(command: nil, print_all: false, print_command: true, error: nil, prefix: nil, admin: false)
-        UI.deprecated("use execute_command instead")
+        # UI.deprecated("use execute_command instead")
         print_all = true if U3dCore::Globals.verbose?
         prefix ||= {}
 

--- a/lib/u3d_core/command_executor.rb
+++ b/lib/u3d_core/command_executor.rb
@@ -57,7 +57,6 @@ module U3dCore
       # @return [String] All the output as string
       # @deprecated
       def execute(command: nil, print_all: false, print_command: true, error: nil, prefix: nil, admin: false)
-        # UI.deprecated("use execute_command instead")
         print_all = true if U3dCore::Globals.verbose?
         prefix ||= {}
 
@@ -84,9 +83,6 @@ module U3dCore
       def execute_command(command: nil, output_callback: nil, print_command: true, error_callback: nil, admin: false)
         command = command.join(' ') if command.is_a?(Array)
         UI.command(command) if print_command
-
-        # this is only used to show the "Loading text"...
-        # UI.command_output(loading) if print_all && loading
 
         command = grant_admin_privileges(command) if admin
 

--- a/lib/u3d_core/command_executor.rb
+++ b/lib/u3d_core/command_executor.rb
@@ -53,26 +53,47 @@ module U3dCore
       # @param print_command [Boolean] Should we print the command that's being executed
       # @param error [Block] A block that's called if an error occurs
       # @param prefix [Array] An array containg a prefix + block which might get applied to the output
-      # @param loading [String] A loading string that is shown before the first output
       # @param admin [Boolean] Do we need admin privilege for this command?
-      # @param keychain [Boolean] Should we fetch admin rights from the keychain on OSX
       # @return [String] All the output as string
-      def execute(command: nil, print_all: false, print_command: true, error: nil, prefix: nil, loading: nil, admin: false)
+      # @deprecated
+      def execute(command: nil, print_all: false, print_command: true, error: nil, prefix: nil, admin: false)
+        UI.deprecated("use execute_command instead")
         print_all = true if U3dCore::Globals.verbose?
         prefix ||= {}
 
+        output_callback = nil
+        if print_all
+          output_callback = proc do |line|
+            # Prefix the current line with a string
+            prefix.each do |element|
+              line = element[:prefix] + line if element[:block] && element[:block].call(line)
+            end
+            UI.command_output(line)
+          end
+        end
+
+        execute_command(command: command, output_callback: output_callback, print_command: print_command, error_callback: error, admin: admin)
+      end
+
+      # @param command [String] The command to be executed
+      # @param output_callback [Block] the command to pass to print output
+      # @param print_command [Boolean] Should we print the command that's being executed
+      # @param error_callback [Block] A block that's called if an error occurs
+      # @param admin [Boolean] Do we need admin privilege for this command?
+      # @return [String] All the output as string
+      def execute_command(command: nil, output_callback: nil, print_command: true, error_callback: nil, admin: false)
         command = command.join(' ') if command.is_a?(Array)
         UI.command(command) if print_command
 
         # this is only used to show the "Loading text"...
-        UI.command_output(loading) if print_all && loading
+        # UI.command_output(loading) if print_all && loading
 
         command = grant_admin_privileges(command) if admin
 
-        execute_command(command: command, print_all: print_all, error: error, prefix: prefix)
+        execute_command_low(command: command, output_callback: output_callback, error_callback: error_callback)
       end
 
-      def execute_command(command: nil, print_all: nil, error: nil, prefix: nil)
+      def execute_command_low(command: nil, output_callback: nil, error_callback: nil)
         output = []
         begin
           status = U3dCore::Runner.run(command) do |stdin, _stdout, _pid|
@@ -80,14 +101,7 @@ module U3dCore
               line = l.strip # strip so that \n gets removed
               output << line
 
-              next unless print_all
-
-              # Prefix the current line with a string
-              prefix.each do |element|
-                line = element[:prefix] + line if element[:block] && element[:block].call(line)
-              end
-
-              UI.command_output(line)
+              output_callback.call(line) if output_callback
             end
           end
           raise "Exit status: #{status}".red if !status.nil? && status.nonzero?
@@ -99,8 +113,8 @@ module U3dCore
           output << ex.to_s
           o = output.join("\n")
           UI.verbose o
-          raise ex unless error
-          error.call(o, nil)
+          raise ex unless error_callback
+          error_callback.call(o, nil)
         end
         return output.join("\n")
       end
@@ -141,6 +155,6 @@ module U3dCore
       end
     end
 
-    private_class_method :execute_command
+    private_class_method :execute_command_low
   end
 end


### PR DESCRIPTION
Testing using `examples/Example1`

```
bundle exec u3d -r -- -logFile /dev/stdout -executeMethod U3d.EditorRun.LoadSaveScenes -quit -batchmode
bundle exec u3d  -- -logFile /dev/stdout -executeMethod U3d.EditorRun.LoadSaveScenes -quit -batchmode
bundle exec u3d -r -- -logFile /tmp/stdout -executeMethod U3d.EditorRun.LoadSaveScenes -quit -batchmode
bundle exec u3d  -- -logFile /tmp/stdout -executeMethod U3d.EditorRun.LoadSaveScenes -quit -batchmode
```

all works on mac

I had to make sure the `\n` is passed to the output_callback by command_executor for it to work.

```

bundle exec u3d -r -- -logFile /dev/stdout -executeMethod U3d.EditorRun.LoadSaveScenes -quit -batchmode -nographics
bundle exec u3d  -- -logFile /dev/stdout -executeMethod U3d.EditorRun.LoadSaveScenes -quit -batchmode -nographics
bundle exec u3d -r -- -logFile /tmp/stdout -executeMethod U3d.EditorRun.LoadSaveScenes -quit -batchmode -nographics
bundle exec u3d  -- -logFile /tmp/stdout -executeMethod U3d.EditorRun.LoadSaveScenes -quit -batchmode -nographics
```

tested on Linux with latest commit.

/tmp/stdout version loses the start of the log.