### PR TITLE
u3d/prettify: add rule to catch library loading errors

### DIFF
--- a/config/log_rules.json
+++ b/config/log_rules.json
@@ -45,6 +45,12 @@
         "store_lines": false,
         "type": "error"
       },
+      "error_shared_library": {
+        "active": true,
+        "start_pattern": "error while loading shared libraries: (?<message>.*)\\n",
+        "start_message": "Error while loading shared libraries: %{message}",
+        "type": "error"
+      },
       "log": {
         "active": true,
         "start_pattern": "UnityEngine\\.Debug:Log\\(Object\\)",


### PR DESCRIPTION
Fixes #123 

Adds a generic rule to catch error messages when there is an issue while loading dependencies on Linux.