### PR TITLE
u3d/analyzer: remove extra end of lines in context information

### DIFF
--- a/lib/u3d/log_analyzer.rb
+++ b/lib/u3d/log_analyzer.rb
@@ -197,8 +197,8 @@ module U3d
       if @active_rule
         # Active rule should be finished
         # If it is still active during phase change, it means that something went wrong
-        context = @lines_memory.map { |l| "\n> #{l}" }.join('')
-        UI.error("[#{@active_phase}] Could not finish active rule '#{@active_rule}'. Aborting it. Context:#{context}")
+        context = @lines_memory.map { |l| "> #{l}" }.join('')
+        UI.error("[#{@active_phase}] Could not finish active rule '#{@active_rule}'. Aborting it. Context:\n#{context}")
         @active_rule = nil
       end
       UI.verbose("--- Ending #{@active_phase} phase ---")


### PR DESCRIPTION
Current implementation was doing:

![image](https://user-images.githubusercontent.com/24282/30412416-a4f927e6-9917-11e7-9d63-30de1c4e267b.png)
