### PR TITLE
u3d/downloader: print progress improvements (fix #164)

### DIFF
--- a/lib/u3d/utils.rb
+++ b/lib/u3d/utils.rb
@@ -59,6 +59,7 @@ module U3d
         end
       end
 
+      # size a hint of the expected size
       def download_file(path, url, size: nil)
         File.open(path, 'wb') do |f|
           uri = URI(url)
@@ -69,7 +70,9 @@ module U3d
             request = Net::HTTP::Get.new uri
             http.request request do |response|
               begin
-                size ||= Integer(response['Content-Length'])
+                # override with actual results, this should help with
+                # innacurrate declared sizes, especially on Windows platform
+                size = Integer(response['Content-Length'])
               rescue ArgumentError
                 UI.verbose 'Unable to get length of file in download'
               end

--- a/lib/u3d/utils.rb
+++ b/lib/u3d/utils.rb
@@ -84,7 +84,12 @@ module U3d
                 # FIXME revisits, this slows down download on fast network
                 # sleep 0.08 # adjust to reduce CPU
                 next unless print_progress
-                next unless Time.now.to_f - last_print_update > 0.5
+                should_print_progress = Time.now.to_f - last_print_update > 0.5
+                # force printing when done downloading
+                if !should_print_progress && size && current >= size
+                  should_print_progress = true
+                end
+                next unless should_print_progress
                 last_print_update = Time.now.to_f
                 if size
                   Utils.print_progress(current, size, started_at)

--- a/lib/u3d/utils.rb
+++ b/lib/u3d/utils.rb
@@ -84,10 +84,10 @@ module U3d
                 # FIXME revisits, this slows down download on fast network
                 # sleep 0.08 # adjust to reduce CPU
                 next unless print_progress
-                should_print_progress = Time.now.to_f - last_print_update > 0.5
+                print_progress_now = Time.now.to_f - last_print_update > 0.5
                 # force printing when done downloading
-                should_print_progress = true if !should_print_progress && size && current >= size
-                next unless should_print_progress
+                print_progress_now = true if !print_progress_now && size && current >= size
+                next unless print_progress_now
                 last_print_update = Time.now.to_f
                 Utils.print_progress(current, size, started_at)
                 print "\n" unless UI.interactive?

--- a/lib/u3d/utils.rb
+++ b/lib/u3d/utils.rb
@@ -86,16 +86,10 @@ module U3d
                 next unless print_progress
                 should_print_progress = Time.now.to_f - last_print_update > 0.5
                 # force printing when done downloading
-                if !should_print_progress && size && current >= size
-                  should_print_progress = true
-                end
+                should_print_progress = true if !should_print_progress && size && current >= size
                 next unless should_print_progress
                 last_print_update = Time.now.to_f
-                if size
-                  Utils.print_progress(current, size, started_at)
-                else
-                  Utils.print_progress_nosize(current, started_at)
-                end
+                Utils.print_progress(current, size, started_at)
                 print "\n" unless UI.interactive?
               end
             end
@@ -130,7 +124,12 @@ module U3d
         FileUtils.mkpath(dir) unless File.directory?(dir)
       end
 
+      # if total is nil (unknown, falls back to print_progress_nosize)
       def print_progress(current, total, started_at)
+        if total.nil?
+          print_progress_nosize(current, started_at)
+          return
+        end
         ratio = [current.to_f / total, 1.0].min
         percent = (ratio * 100.0).round(1)
         arrow = (ratio * 20.0).floor


### PR DESCRIPTION
Always use the server declared size first, and force printing when done.

This should solve inaccurate Windows package sizes and fix #164