### PR TITLE
Fix log termination

### DIFF
--- a/config/log_rules.json
+++ b/config/log_rules.json
@@ -61,7 +61,7 @@
         "fetched_line_pattern": "(?<message>.*)\\n",
         "fetched_line_message": false,
         "start_message": false,
-        "end_pattern": "Filename: (?:[\\w/:]+/(?<file>\\w+\\.\\w+))? Line: (?<line>-?\\d+)",
+        "end_pattern": "Filename: (?:.+/(?<file>\\w+\\.\\w+))? Line: (?<line>-?\\d+)",
         "end_message": "[LOG] %{file}(line %{line}): %{message}"
       },
       "log_assertion": {

--- a/lib/u3d/log_analyzer.rb
+++ b/lib/u3d/log_analyzer.rb
@@ -78,7 +78,7 @@ module U3d
       @phases.each do |name, phase|
         next if name == @active_phase
         next unless line =~ phase['phase_start_pattern']
-        finish_phase
+        finish_phase if @active_phase
         @active_phase = name
         UI.verbose("--- Beginning #{name} phase ---")
         break


### PR DESCRIPTION
* Some log rules could not be ended in projects with strange characters in the path to the file logging.

* Also fixes the fact that u3d tried to finish the active phase even though there was none.