### PR TITLE
Fix unity_version argument of fastlane plugin u3d type

### DIFF
--- a/fastlane-plugin-u3d/lib/fastlane/plugin/u3d/actions/u3d_action.rb
+++ b/fastlane-plugin-u3d/lib/fastlane/plugin/u3d/actions/u3d_action.rb
@@ -57,7 +57,7 @@ module Fastlane
                                   env_name: "U3D_VERSION",
                                description: "Unity version",
                                   optional: true,
-                                      type: Array),
+                                      type: String),
           FastlaneCore::ConfigItem.new(key: :raw_logs,
           #                       env_name: "U3D_YOUR_OPTION",
                                description: "Disable u3d log parsing",


### PR DESCRIPTION
Calls to the plugin are failing when the option is specified because the type is not correct.