### PR TITLE
u3d/install: do not reinstall already installed packages

### DIFF
--- a/lib/u3d/commands.rb
+++ b/lib/u3d/commands.rb
@@ -328,8 +328,10 @@ module U3d
             options[:installation_path] ||= unity.root_path if definition.os == :win
           end
           if unity.packages
-            unity.packages.each do |pack|
-              UI.important "Ignoring #{pack} module, it is already installed" if packages.delete(pack)
+            packages.each do |pack|
+              if unity.packages.include?(pack) || unity.packages.any? { |installed| package_aliases[pack].include?(installed) }
+                UI.important "Ignoring #{pack} module, it is already installed" if packages.delete(pack)
+              end
             end
           end
           return false if packages.empty?
@@ -340,6 +342,23 @@ module U3d
           end
         end
         true
+    end
+
+      def package_aliases
+        {
+          'Android' => [],
+          'iOS' => ['iPhone'],
+          'AppleTV' => [],
+          'Linux' => ['StandaloneLinux'],
+          'Mac' => %w[StandaloneOSXIntel StandaloneOSXIntel64 StandaloneOSX],
+          'Windows' => ['StandaloneWindows'],
+          'Metro' => [],
+          'UWP-IL2CPP' => [],
+          'Samsung-TV' => [],
+          'Tizen' => [],
+          'WebGL' => [],
+          'Facebook-Games' => []
+        }
       end
 
       def get_administrative_privileges(options)

--- a/lib/u3d/commands.rb
+++ b/lib/u3d/commands.rb
@@ -327,9 +327,10 @@ module U3d
             # FIXME: Move me to the WindowsInstaller
             options[:installation_path] ||= unity.root_path if definition.os == :win
           end
-          if unity.packages
+		  if unity.packages
+			installed_packages = unity.packages
 			packages.each do |pack|
-              if unity.packages.include?(pack) || unity.packages.any? { |installed| !package_aliases[pack].nil? && package_aliases[pack].include?(installed) }
+              if installed_packages.include?(pack) || installed_packages.any? { |installed| !package_aliases[pack].nil? && package_aliases[pack].include?(installed) }
                 UI.important "Ignoring #{pack} module, it is already installed" if packages.delete(pack)
               end
             end

--- a/lib/u3d/commands.rb
+++ b/lib/u3d/commands.rb
@@ -328,8 +328,8 @@ module U3d
             options[:installation_path] ||= unity.root_path if definition.os == :win
           end
           if unity.packages
-            packages.each do |pack|
-              if unity.packages.include?(pack) || unity.packages.any? { |installed| package_aliases[pack].include?(installed) }
+			packages.each do |pack|
+              if unity.packages.include?(pack) || unity.packages.any? { |installed| !package_aliases[pack].nil? && package_aliases[pack].include?(installed) }
                 UI.important "Ignoring #{pack} module, it is already installed" if packages.delete(pack)
               end
             end

--- a/lib/u3d/commands.rb
+++ b/lib/u3d/commands.rb
@@ -327,7 +327,7 @@ module U3d
             # FIXME: Move me to the WindowsInstaller
             options[:installation_path] ||= unity.root_path if definition.os == :win
           end
-          skippable_packages(unity, packages).each do |pack|
+          packages.select { |pack| unity.package_installed?(pack) }.each do |pack|
             packages.delete pack
             UI.important "Ignoring #{pack} module, it is already installed"
           end
@@ -339,45 +339,6 @@ module U3d
           end
         end
         true
-      end
-
-      def skippable_packages(unity, packages)
-        return [] if unity.packages.nil?
-        result = []
-
-        installed_packages = unity.packages
-        packages.each do |pack|
-          result << pack if package_installed?(pack, installed_packages)
-        end
-
-        result
-      end
-
-      def package_installed?(package, installed_packages)
-        return true if installed_packages.include?(package)
-
-        aliases = package_aliases[package]
-        return false if package_aliases[package].nil?
-
-        return !(aliases & installed_packages).empty?
-      end
-
-      def package_aliases
-        {
-          'Android' => [],
-          'iOS' => ['iPhone'],
-          'AppleTV' => ['tvOS'],
-          'Linux' => ['StandaloneLinux'],
-          'Mac' => %w[StandaloneOSXIntel StandaloneOSXIntel64 StandaloneOSX],
-          'Windows' => ['StandaloneWindows'],
-          'Metro' => [],
-          'UWP-IL2CPP' => [],
-          'Samsung-TV' => [],
-          'Tizen' => [],
-          'WebGL' => [],
-          'Facebook-Games' => ['Facebook'],
-          'Vuforia-AR' => ['UnityExtensions']
-        }
       end
 
       def get_administrative_privileges(options)

--- a/lib/u3d/commands.rb
+++ b/lib/u3d/commands.rb
@@ -327,9 +327,9 @@ module U3d
             # FIXME: Move me to the WindowsInstaller
             options[:installation_path] ||= unity.root_path if definition.os == :win
           end
-		  if unity.packages
-			installed_packages = unity.packages
-			packages.each do |pack|
+          if unity.packages
+            installed_packages = unity.packages
+            packages.each do |pack|
               if installed_packages.include?(pack) || installed_packages.any? { |installed| !package_aliases[pack].nil? && package_aliases[pack].include?(installed) }
                 UI.important "Ignoring #{pack} module, it is already installed" if packages.delete(pack)
               end
@@ -343,7 +343,7 @@ module U3d
           end
         end
         true
-    end
+      end
 
       def package_aliases
         {

--- a/lib/u3d/commands.rb
+++ b/lib/u3d/commands.rb
@@ -348,7 +348,7 @@ module U3d
         {
           'Android' => [],
           'iOS' => ['iPhone'],
-          'AppleTV' => [],
+          'AppleTV' => ['tvOS'],
           'Linux' => ['StandaloneLinux'],
           'Mac' => %w[StandaloneOSXIntel StandaloneOSXIntel64 StandaloneOSX],
           'Windows' => ['StandaloneWindows'],
@@ -357,7 +357,8 @@ module U3d
           'Samsung-TV' => [],
           'Tizen' => [],
           'WebGL' => [],
-          'Facebook-Games' => []
+          'Facebook-Games' => ['Facebook'],
+          'Vuforia-AR' => ['UnityExtensions']
         }
       end
 

--- a/lib/u3d/commands.rb
+++ b/lib/u3d/commands.rb
@@ -340,19 +340,19 @@ module U3d
         end
         true
       end
-      
+
       def skippable_packages(unity, packages)
         return [] if unity.packages.nil?
         result = []
 
-        installed_packages = unity.packages        
+        installed_packages = unity.packages
         packages.each do |pack|
           result << pack if package_installed?(pack, installed_packages)
         end
-        
+
         result
       end
-      
+
       def package_installed?(package, installed_packages)
         return true if installed_packages.include?(package)
 

--- a/lib/u3d/installation.rb
+++ b/lib/u3d/installation.rb
@@ -71,7 +71,10 @@ module U3d
       return true if (packages || []).include?(package)
 
       aliases = PACKAGE_ALIASES[package]
-      return false if aliases[package].nil?
+
+      # If no aliases for the package are found, then it's a new package not yet known by Unity
+      # If the exact name doesn't match then we have to suppose it's not installed
+      return false unless aliases
 
       return !(aliases & packages).empty?
     end

--- a/lib/u3d/installation.rb
+++ b/lib/u3d/installation.rb
@@ -178,11 +178,27 @@ module U3d
     end
 
     def packages
-      path = "#{root_path}/Editor/Data/"
-      PlaybackEngineUtils.list_module_configs(path).map do |mpath|
-        PlaybackEngineUtils.module_name(mpath)
-      end
-    end
+	  path = "#{root_path}/Editor/Data/"
+	  pack = []
+      PlaybackEngineUtils.list_module_configs(path).each do |mpath|
+        pack << PlaybackEngineUtils.module_name(mpath)
+	  end
+	  pack << 'Documentation' if has_documentation?
+	  pack << 'StandardAssets' if has_standard_assets?
+	  pack
+	end
+	
+	def has_documentation?
+	  has_specific_dir?("#{root_path}/Editor/Data/Documentation/", check_empty: true)
+	end
+
+	def has_standard_assets?
+	  has_specific_dir?("#{root_path}/Editor/Standard Assets/", check_empty: true)  
+	end
+	
+	def has_specific_dir?(directory, check_empty: false)
+	  File.directory?(directory) && (check_empty || Dir[File.join(directory, '*')].empty?)
+	end
 
     def clean_install?
       !(root_path =~ UNITY_DIR_CHECK).nil?

--- a/lib/u3d/installation.rb
+++ b/lib/u3d/installation.rb
@@ -30,6 +30,22 @@ module U3d
     attr_reader :root_path
 
     NOT_PLAYBACKENGINE_PACKAGES = %w[Documentation StandardAssets MonoDevelop].freeze
+    PACKAGE_ALIASES =
+      {
+        'Android' => [],
+        'iOS' => ['iPhone'],
+        'AppleTV' => ['tvOS'],
+        'Linux' => ['StandaloneLinux'],
+        'Mac' => %w[StandaloneOSXIntel StandaloneOSXIntel64 StandaloneOSX],
+        'Windows' => ['StandaloneWindows'],
+        'Metro' => [],
+        'UWP-IL2CPP' => [],
+        'Samsung-TV' => [],
+        'Tizen' => [],
+        'WebGL' => [],
+        'Facebook-Games' => ['Facebook'],
+        'Vuforia-AR' => ['UnityExtensions']
+      }.freeze
 
     def initialize(root_path: nil, path: nil)
       @root_path = root_path
@@ -47,24 +63,6 @@ module U3d
       end
     end
 
-    def self.package_aliases
-      {
-        'Android' => [],
-        'iOS' => ['iPhone'],
-        'AppleTV' => ['tvOS'],
-        'Linux' => ['StandaloneLinux'],
-        'Mac' => %w[StandaloneOSXIntel StandaloneOSXIntel64 StandaloneOSX],
-        'Windows' => ['StandaloneWindows'],
-        'Metro' => [],
-        'UWP-IL2CPP' => [],
-        'Samsung-TV' => [],
-        'Tizen' => [],
-        'WebGL' => [],
-        'Facebook-Games' => ['Facebook'],
-        'Vuforia-AR' => ['UnityExtensions']
-      }
-    end
-
     def packages
       false
     end
@@ -72,7 +70,7 @@ module U3d
     def package_installed?(package)
       return true if (packages || []).include?(package)
 
-      aliases = Installation.package_aliases[package]
+      aliases = PACKAGE_ALIASES[package]
       return false if aliases[package].nil?
 
       return !(aliases & packages).empty?

--- a/lib/u3d/installation.rb
+++ b/lib/u3d/installation.rb
@@ -183,21 +183,14 @@ module U3d
       PlaybackEngineUtils.list_module_configs(path).each do |mpath|
         pack << PlaybackEngineUtils.module_name(mpath)
       end
-      pack << 'Documentation' if documentation?
-      pack << 'StandardAssets' if standard_assets?
+      pack << 'Documentation' if specific_dir?("#{root_path}/Editor/Data/Documentation/", check_empty: true)
+	  pack << 'StandardAssets' if specific_dir?("#{root_path}/Editor/Standard Assets/", check_empty: true)
+	  pack << 'MonoDevelop' if specific_dir?("#{root_path}/MonoDevelop/")
       pack
     end
 
-    def documentation?
-      specific_dir?("#{root_path}/Editor/Data/Documentation/", check_empty: true)
-    end
-
-    def standard_assets?
-      specific_dir?("#{root_path}/Editor/Standard Assets/", check_empty: true)
-    end
-
-    def specific_dir?(directory, check_empty: false)
-      File.directory?(directory) && (check_empty || Dir[File.join(directory, '*')].empty?)
+	def specific_dir?(directory, check_empty: false)
+	  File.directory?(directory) && (check_empty || !Dir[File.join(directory, '*')].empty?)
     end
 
     def clean_install?

--- a/lib/u3d/installation.rb
+++ b/lib/u3d/installation.rb
@@ -68,9 +68,7 @@ module U3d
     end
 
     def package_installed?(package)
-      return false unless packages
-
-      return true if packages.include?(package)
+      return true if (packages || []).include?(package)
 
       aliases = Installation.package_aliases[package]
       return false if aliases[package].nil?

--- a/lib/u3d/installation.rb
+++ b/lib/u3d/installation.rb
@@ -183,14 +183,23 @@ module U3d
       PlaybackEngineUtils.list_module_configs(path).each do |mpath|
         pack << PlaybackEngineUtils.module_name(mpath)
       end
-      pack << 'Documentation' if specific_dir?("#{root_path}/Editor/Data/Documentation/", check_empty: true)
-      pack << 'StandardAssets' if specific_dir?("#{root_path}/Editor/Standard Assets/", check_empty: true)
-      pack << 'MonoDevelop' if specific_dir?("#{root_path}/MonoDevelop/")
+      ['Documentation', 'StandardAssets', 'MonoDevelop'].each do |module_name|
+        pack << module_name unless Dir[module_name_pattern(module_name)].empty?
+      end
       pack
     end
-
-    def specific_dir?(directory, check_empty: false)
-      File.directory?(directory) && (check_empty || !Dir[File.join(directory, '*')].empty?)
+    
+    def module_name_pattern(module_name)
+      case module_name
+      when 'Documentation'
+        return "#{root_path}/Editor/Data/Documentation/"
+      when 'StandardAssets'
+        return "#{root_path}/Editor/Standard Assets/"
+      when 'MonoDevelop'
+        return "#{root_path}/MonoDevelop/"
+      else
+        return ''
+      end
     end
 
     def clean_install?

--- a/lib/u3d/installation.rb
+++ b/lib/u3d/installation.rb
@@ -178,27 +178,27 @@ module U3d
     end
 
     def packages
-	  path = "#{root_path}/Editor/Data/"
-	  pack = []
+      path = "#{root_path}/Editor/Data/"
+      pack = []
       PlaybackEngineUtils.list_module_configs(path).each do |mpath|
         pack << PlaybackEngineUtils.module_name(mpath)
-	  end
-	  pack << 'Documentation' if has_documentation?
-	  pack << 'StandardAssets' if has_standard_assets?
-	  pack
-	end
-	
-	def has_documentation?
-	  has_specific_dir?("#{root_path}/Editor/Data/Documentation/", check_empty: true)
-	end
+      end
+      pack << 'Documentation' if documentation?
+      pack << 'StandardAssets' if standard_assets?
+      pack
+    end
 
-	def has_standard_assets?
-	  has_specific_dir?("#{root_path}/Editor/Standard Assets/", check_empty: true)  
-	end
-	
-	def has_specific_dir?(directory, check_empty: false)
-	  File.directory?(directory) && (check_empty || Dir[File.join(directory, '*')].empty?)
-	end
+    def documentation?
+      specific_dir?("#{root_path}/Editor/Data/Documentation/", check_empty: true)
+    end
+
+    def standard_assets?
+      specific_dir?("#{root_path}/Editor/Standard Assets/", check_empty: true)
+    end
+
+    def specific_dir?(directory, check_empty: false)
+      File.directory?(directory) && (check_empty || Dir[File.join(directory, '*')].empty?)
+    end
 
     def clean_install?
       !(root_path =~ UNITY_DIR_CHECK).nil?

--- a/lib/u3d/installation.rb
+++ b/lib/u3d/installation.rb
@@ -142,7 +142,7 @@ module U3d
       when 'MonoDevelop'
         return "#{root_path}/MonoDevelop.app/"
       else
-        return ''
+        UI.user_error! "No pattern is known for #{module_name} on Mac"
       end
     end
 
@@ -245,7 +245,7 @@ module U3d
       when 'MonoDevelop'
         return "#{root_path}/MonoDevelop/"
       else
-        return ''
+        UI.user_error! "No pattern is known for #{module_name} on Windows"
       end
     end
 

--- a/lib/u3d/installation.rb
+++ b/lib/u3d/installation.rb
@@ -90,8 +90,26 @@ module U3d
     end
 
     def packages
-      PlaybackEngineUtils.list_module_configs(root_path).map do |mpath|
-        PlaybackEngineUtils.module_name(mpath)
+      pack = []
+      PlaybackEngineUtils.list_module_configs(root_path).each do |mpath|
+        pack << PlaybackEngineUtils.module_name(mpath)
+      end
+      ['Documentation', 'StandardAssets', 'MonoDevelop'].each do |module_name|
+        pack << module_name unless Dir[module_name_pattern(module_name)].empty?
+      end
+      pack
+    end
+
+    def module_name_pattern(module_name)
+      case module_name
+      when 'Documentation'
+        return "#{root_path}/Documentation/"
+      when 'StandardAssets'
+        return "#{root_path}/Standard Assets/"
+      when 'MonoDevelop'
+        return "#{root_path}/MonoDevelop.app/"
+      else
+        return ''
       end
     end
 

--- a/lib/u3d/installation.rb
+++ b/lib/u3d/installation.rb
@@ -184,13 +184,13 @@ module U3d
         pack << PlaybackEngineUtils.module_name(mpath)
       end
       pack << 'Documentation' if specific_dir?("#{root_path}/Editor/Data/Documentation/", check_empty: true)
-	  pack << 'StandardAssets' if specific_dir?("#{root_path}/Editor/Standard Assets/", check_empty: true)
-	  pack << 'MonoDevelop' if specific_dir?("#{root_path}/MonoDevelop/")
+      pack << 'StandardAssets' if specific_dir?("#{root_path}/Editor/Standard Assets/", check_empty: true)
+      pack << 'MonoDevelop' if specific_dir?("#{root_path}/MonoDevelop/")
       pack
     end
 
-	def specific_dir?(directory, check_empty: false)
-	  File.directory?(directory) && (check_empty || !Dir[File.join(directory, '*')].empty?)
+    def specific_dir?(directory, check_empty: false)
+      File.directory?(directory) && (check_empty || !Dir[File.join(directory, '*')].empty?)
     end
 
     def clean_install?

--- a/lib/u3d/installation.rb
+++ b/lib/u3d/installation.rb
@@ -140,7 +140,7 @@ module U3d
       when 'MonoDevelop'
         return "#{root_path}/MonoDevelop.app/"
       else
-        UI.user_error! "No pattern is known for #{module_name} on Mac"
+        UI.crash! "No pattern is known for #{module_name} on Mac"
       end
     end
 
@@ -243,7 +243,7 @@ module U3d
       when 'MonoDevelop'
         return "#{root_path}/MonoDevelop/"
       else
-        UI.user_error! "No pattern is known for #{module_name} on Windows"
+        UI.crash! "No pattern is known for #{module_name} on Windows"
       end
     end
 

--- a/lib/u3d/installation.rb
+++ b/lib/u3d/installation.rb
@@ -44,6 +44,39 @@ module U3d
         WindowsInstallation.new(root_path: root_path, path: path)
       end
     end
+
+    def self.package_aliases
+      {
+        'Android' => [],
+        'iOS' => ['iPhone'],
+        'AppleTV' => ['tvOS'],
+        'Linux' => ['StandaloneLinux'],
+        'Mac' => %w[StandaloneOSXIntel StandaloneOSXIntel64 StandaloneOSX],
+        'Windows' => ['StandaloneWindows'],
+        'Metro' => [],
+        'UWP-IL2CPP' => [],
+        'Samsung-TV' => [],
+        'Tizen' => [],
+        'WebGL' => [],
+        'Facebook-Games' => ['Facebook'],
+        'Vuforia-AR' => ['UnityExtensions']
+      }
+    end
+
+    def packages
+      false
+    end
+
+    def package_installed?(package)
+      return false unless packages
+
+      return true if packages.include?(package)
+
+      aliases = Installation.package_aliases[package]
+      return false if aliases[package].nil?
+
+      return !(aliases & packages).empty?
+    end
   end
 
   class PlaybackEngineUtils
@@ -153,10 +186,6 @@ module U3d
     def path
       UI.deprecated("path is deprecated. Use root_path instead")
       @root_path || @path
-    end
-
-    def packages
-      false
     end
 
     def clean_install?

--- a/lib/u3d/installation.rb
+++ b/lib/u3d/installation.rb
@@ -29,6 +29,8 @@ module U3d
   class Installation
     attr_reader :root_path
 
+    NOT_PLAYBACKENGINE_PACKAGES = %w[Documentation StandardAssets MonoDevelop].freeze
+
     def initialize(root_path: nil, path: nil)
       @root_path = root_path
       @path = path
@@ -125,7 +127,7 @@ module U3d
       PlaybackEngineUtils.list_module_configs(root_path).each do |mpath|
         pack << PlaybackEngineUtils.module_name(mpath)
       end
-      %w[Documentation StandardAssets MonoDevelop].each do |module_name|
+      NOT_PLAYBACKENGINE_PACKAGES.each do |module_name|
         pack << module_name unless Dir[module_name_pattern(module_name)].empty?
       end
       pack
@@ -228,7 +230,7 @@ module U3d
       PlaybackEngineUtils.list_module_configs(path).each do |mpath|
         pack << PlaybackEngineUtils.module_name(mpath)
       end
-      %w[Documentation StandardAssets MonoDevelop].each do |module_name|
+      NOT_PLAYBACKENGINE_PACKAGES.each do |module_name|
         pack << module_name unless Dir[module_name_pattern(module_name)].empty?
       end
       pack

--- a/lib/u3d/installation.rb
+++ b/lib/u3d/installation.rb
@@ -94,7 +94,7 @@ module U3d
       PlaybackEngineUtils.list_module_configs(root_path).each do |mpath|
         pack << PlaybackEngineUtils.module_name(mpath)
       end
-      ['Documentation', 'StandardAssets', 'MonoDevelop'].each do |module_name|
+      %w[Documentation StandardAssets MonoDevelop].each do |module_name|
         pack << module_name unless Dir[module_name_pattern(module_name)].empty?
       end
       pack
@@ -201,12 +201,12 @@ module U3d
       PlaybackEngineUtils.list_module_configs(path).each do |mpath|
         pack << PlaybackEngineUtils.module_name(mpath)
       end
-      ['Documentation', 'StandardAssets', 'MonoDevelop'].each do |module_name|
+      %w[Documentation StandardAssets MonoDevelop].each do |module_name|
         pack << module_name unless Dir[module_name_pattern(module_name)].empty?
       end
       pack
     end
-    
+
     def module_name_pattern(module_name)
       case module_name
       when 'Documentation'

--- a/spec/support/installations.rb
+++ b/spec/support/installations.rb
@@ -95,6 +95,6 @@ def fake_installation(version, packages: [])
   allow(unity).to receive(:version) { version }
   allow(unity).to receive(:root_path) { 'foo' }
   allow(unity).to receive(:packages) { packages }
-  unity.stub(:package_installed?) { |arg| packages.include?(arg) }
+  allow(unity).to receive(:package_installed?) { |arg| packages.include?(arg) }
   return unity
 end

--- a/spec/support/installations.rb
+++ b/spec/support/installations.rb
@@ -95,5 +95,6 @@ def fake_installation(version, packages: [])
   allow(unity).to receive(:version) { version }
   allow(unity).to receive(:root_path) { 'foo' }
   allow(unity).to receive(:packages) { packages }
+  unity.stub(:package_installed?) { |arg| packages.include?(arg) }
   return unity
 end


### PR DESCRIPTION
Fixes #198 

This solve the issues of non-matching package name between installed and available by:

- Mapping the names of the installed package and the available package
- Detecting some folders on the local install for "special package" (Documentation, Standard Assets...)