### PR TITLE
u3d/prettify: update ruleset with LICENSE SYSTEM rules

### DIFF
--- a/config/log_rules.json
+++ b/config/log_rules.json
@@ -149,6 +149,66 @@
       }
     }
   },
+  "LICENSE": {
+    "active": true,
+    "silent": false,
+    "comment": "Unity license system logic",
+    "phase_start_pattern": "LICENSE SYSTEM",
+    "rules": {
+      "next_check": {
+        "active": true,
+        "start_pattern": "LICENSE SYSTEM \\[.*\\] Next license update check is after (?<date>[\\d\\-]+)T(?<time>[\\d+\\:]+)",
+        "start_message": "Next update check after %{date} at %{time}"
+      },
+      "opening": {
+        "active": true,
+        "start_pattern": "LICENSE SYSTEM \\[.*\\] Opening (?<address>.*)$",
+        "start_message": "Opening %{address}",
+        "store_lines": false,
+        "end_pattern": "(?:\\[CEF\\]|LICENSE SYSTEM \\[.*\\] Received)",
+        "end_message": false
+      },
+      "received": {
+        "active": true,
+        "start_pattern": "LICENSE SYSTEM \\[.*\\] Received (?<address>.*)$",
+        "start_message": "Received %{address}",
+        "store_lines": false,
+        "end_pattern": "(?:\\[CEF\\]|LICENSE SYSTEM \\[.*\\] (?!Headers)|Cancelling)",
+        "end_message": false
+      },
+      "cef_undefined": {
+        "active": true,
+        "start_pattern": "\\[CEF\\] undefined in.*$",
+        "type": "warning"
+      },
+      "error": {
+        "active": true,
+        "start_pattern": "LICENSE SYSTEM \\[.*\\] (?<message>Error.*)",
+        "start_message": "%{message}",
+        "store_lines": true,
+        "end_pattern": "(?:^\\n|\\[CEF\\] undefined)",
+        "end_message": false,
+        "type": "error"
+      },
+      "timeout": {
+        "active": true,
+        "start_pattern": "Cancelling.*Timeout",
+        "start_message": "Timeout while trying to activate license. Please try again later or contact support@unity3d.com",
+        "type": "error"
+      },
+      "starting_activation": {
+        "active": true,
+        "start_pattern": "LICENSE SYSTEM \\[.*\\] Starting license activation with account (?<account>.*)$",
+        "start_message": "Starting license activation for account %{account}"
+      },
+      "successful_activation": {
+        "active": true,
+        "start_pattern": "LICENSE SYSTEM \\[.*\\] License activated successfully with user: (?<account>.*)$",
+        "start_message": "License activated for account %{account}",
+        "type": "success"
+      }
+    }
+  },
   "INIT": {
     "active": true,
     "silent": false,

--- a/spec/u3d/log_analyzer_spec.rb
+++ b/spec/u3d/log_analyzer_spec.rb
@@ -66,7 +66,7 @@ describe U3d do
       it "loads defaults rules without problem" do
         gen, phases = U3d::LogAnalyzer.new.load_rules
         expect(gen.keys.count).to be > 5
-        expect(phases.keys).to eq %w[JENKINS INIT COMPILER ASSET]
+        expect(phases.keys).to eq %w[JENKINS LICENSE INIT COMPILER ASSET]
       end
 
       it "parses a simple file" do


### PR DESCRIPTION
This adds rules to the prettifier so that all the license-related informations appear in the logs.
  