### PR TITLE
u3d/prettify: remove Jenkins rules

### DIFF
--- a/config/log_rules.json
+++ b/config/log_rules.json
@@ -137,18 +137,6 @@
       }
     }
   },
-  "JENKINS": {
-    "active": true,
-    "silent": false,
-    "comment": "Jenkins specific, used to catch build launchs via Jenkins",
-    "phase_start_pattern": "Started by",
-    "rules": {
-      "start": {
-        "active": true,
-        "start_pattern": "Started by"
-      }
-    }
-  },
   "LICENSE": {
     "active": true,
     "silent": false,

--- a/spec/u3d/log_analyzer_spec.rb
+++ b/spec/u3d/log_analyzer_spec.rb
@@ -66,7 +66,7 @@ describe U3d do
       it "loads defaults rules without problem" do
         gen, phases = U3d::LogAnalyzer.new.load_rules
         expect(gen.keys.count).to be > 5
-        expect(phases.keys).to eq %w[JENKINS LICENSE INIT COMPILER ASSET]
+        expect(phases.keys).to eq %w[LICENSE INIT COMPILER ASSET]
       end
 
       it "parses a simple file" do


### PR DESCRIPTION
This removes all jenkins-specific rules as they do not belong in u3d.