### PR TITLE
u3d/install: allow to specify packages download directory using an environment variable

### DIFF
--- a/lib/u3d/commands_generator.rb
+++ b/lib/u3d/commands_generator.rb
@@ -133,6 +133,10 @@ This command allows you to either:
 * install already downloaded packages
 
 Already installed packages are skipped if asked to be installed again (except for the 'Example' package).
+
+The default download path is $HOME/Downloads/Unity_Packages/, but you may change that by specifying the environment variable U3D_DOWNLOAD_PATH.
+
+E.g. U3D_RULES_PATH=/some/path/you/want u3d install ...
         )
         c.option '--[no-]download', 'Perform or not downloading before installation. Downloads by default'
         c.option '--[no-]install', 'Perform or not installation after downloading. Installs by default'

--- a/lib/u3d/commands_generator.rb
+++ b/lib/u3d/commands_generator.rb
@@ -136,7 +136,7 @@ Already installed packages are skipped if asked to be installed again (except fo
 
 The default download path is $HOME/Downloads/Unity_Packages/, but you may change that by specifying the environment variable U3D_DOWNLOAD_PATH.
 
-E.g. U3D_RULES_PATH=/some/path/you/want u3d install ...
+E.g. U3D_DOWNLOAD_PATH=/some/path/you/want u3d install ...
         )
         c.option '--[no-]download', 'Perform or not downloading before installation. Downloads by default'
         c.option '--[no-]install', 'Perform or not installation after downloading. Installs by default'

--- a/lib/u3d/downloader.rb
+++ b/lib/u3d/downloader.rb
@@ -34,6 +34,10 @@ module U3d
     UNITY_MODULE_FILE_REGEX = %r{\/([\w\-_\.\+]+\.(?:pkg|exe|zip|sh|deb))}
 
     class << self
+      def download_directory
+        File.expand_path(ENV['U3D_DOWNLOAD_PATH'] || File.join(DOWNLOAD_PATH, DOWNLOAD_DIRECTORY))
+      end
+
       # fetch modules and put them in local cache
       def fetch_modules(definition, packages: [], download: nil)
         if download
@@ -134,7 +138,7 @@ module U3d
 
     class MacDownloader
       def destination_for(package, definition)
-        dir = File.join(DOWNLOAD_PATH, DOWNLOAD_DIRECTORY, definition.version)
+        dir = File.join(Downloader.download_directory, definition.version)
         Utils.ensure_dir(dir)
         file_name = UNITY_MODULE_FILE_REGEX.match(definition[package]['url'])[1]
 
@@ -148,7 +152,7 @@ module U3d
 
     class LinuxDownloader
       def destination_for(package, definition)
-        dir = File.join(DOWNLOAD_PATH, DOWNLOAD_DIRECTORY, definition.version)
+        dir = File.join(Downloader.download_directory, definition.version)
         Utils.ensure_dir(dir)
         file_name = UNITY_MODULE_FILE_REGEX.match(definition[package]['url'])[1]
 
@@ -162,7 +166,7 @@ module U3d
 
     class WindowsDownloader
       def destination_for(package, definition)
-        dir = File.join(DOWNLOAD_PATH, DOWNLOAD_DIRECTORY, definition.version)
+        dir = File.join(Downloader.download_directory, definition.version)
         Utils.ensure_dir(dir)
         file_name = UNITY_MODULE_FILE_REGEX.match(definition[package]['url'])[1]
 

--- a/lib/u3d/downloader.rb
+++ b/lib/u3d/downloader.rb
@@ -117,6 +117,7 @@ module U3d
 
         UI.header "Downloading #{package} version #{definition.version}"
         UI.message 'Downloading from ' + url.to_s.cyan.underline
+        UI.message 'Download will be found at ' + path
         download_package(path, url, size: definition.size_in_bytes(package))
 
         if validator.validate(package, path, definition)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -54,9 +54,8 @@ ensure
 end
 
 def warn_if_env(variable)
-  if ENV[variable] && !ENV[variable].empty?
-    puts "[WARNING] Environment variable #{variable} should not be assigned during testing. Results may be affected."
-  end
+  return unless ENV[variable] && !ENV[variable].empty?
+  puts "[WARNING] Environment variable #{variable} should not be assigned during testing. Results may be affected."
 end
 
 def capture_stds

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -53,6 +53,12 @@ ensure
   end
 end
 
+def warn_if_env(variable)
+  if ENV[variable] && !ENV[variable].empty?
+    puts "[WARNING] Environment variable #{variable} should not be assigned during testing. Results may be affected."
+  end
+end
+
 def capture_stds
   require "stringio"
   orig_stdout = $stdout

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -53,11 +53,6 @@ ensure
   end
 end
 
-def warn_if_env(variable)
-  return unless ENV[variable] && !ENV[variable].empty?
-  puts "[WARNING] Environment variable #{variable} should not be assigned during testing. Results may be affected."
-end
-
 def capture_stds
   require "stringio"
   orig_stdout = $stdout

--- a/spec/u3d/downloader_spec.rb
+++ b/spec/u3d/downloader_spec.rb
@@ -387,18 +387,19 @@ describe U3d do
 
       describe '.destination_for' do
         it 'returns the correct default destination for the Unity installer' do
-          warn_if_env('U3D_DOWNLOAD_PATH')
-          expect(U3d::Utils).to receive(:ensure_dir) {}
-          allow(U3d::INIparser).to receive(:load_ini) { { 'Unity' => { 'url' => 'http://download.unity3d.com/download_unity/linux/unity-editor-installer-1.2.3f4+20160628.sh' } } }
+          with_env_values('U3D_DOWNLOAD_PATH' => nil) do
+            expect(U3d::Utils).to receive(:ensure_dir) {}
+            allow(U3d::INIparser).to receive(:load_ini) { { 'Unity' => { 'url' => 'http://download.unity3d.com/download_unity/linux/unity-editor-installer-1.2.3f4+20160628.sh' } } }
 
-          definition = U3d::UnityVersionDefinition.new('1.2.3f4', :linux, nil)
+            definition = U3d::UnityVersionDefinition.new('1.2.3f4', :linux, nil)
 
-          expect(
-            @downloader.destination_for(
-              'Unity',
-              definition
-            )
-          ).to eql File.join(ENV['HOME'], 'Downloads', 'Unity_Packages', '1.2.3f4', 'unity-editor-installer-1.2.3f4+20160628.sh')
+            expect(
+              @downloader.destination_for(
+                'Unity',
+                definition
+              )
+            ).to eql File.join(ENV['HOME'], 'Downloads', 'Unity_Packages', '1.2.3f4', 'unity-editor-installer-1.2.3f4+20160628.sh')
+          end
         end
 
         it 'returns the custom destination for the Unity installer when the environment variable is specified' do
@@ -440,18 +441,19 @@ describe U3d do
 
       describe '.destination_for' do
         it 'returns the correct default destination for the specified package' do
-          warn_if_env('U3D_DOWNLOAD_PATH')
-          expect(U3d::Utils).to receive(:ensure_dir) {}
-          allow(U3d::INIparser).to receive(:load_ini) { { 'package' => { 'url' => 'MacEditorInstaller/Unity.pkg' } } }
+          with_env_values('U3D_DOWNLOAD_PATH' => nil) do
+            expect(U3d::Utils).to receive(:ensure_dir) {}
+            allow(U3d::INIparser).to receive(:load_ini) { { 'package' => { 'url' => 'MacEditorInstaller/Unity.pkg' } } }
 
-          definition = U3d::UnityVersionDefinition.new('1.2.3f4', :mac, nil)
+            definition = U3d::UnityVersionDefinition.new('1.2.3f4', :mac, nil)
 
-          expect(
-            @downloader.destination_for(
-              'package',
-              definition
-            )
-          ).to eql File.join(ENV['HOME'], 'Downloads', 'Unity_Packages', '1.2.3f4', 'Unity.pkg')
+            expect(
+              @downloader.destination_for(
+                'package',
+                definition
+              )
+            ).to eql File.join(ENV['HOME'], 'Downloads', 'Unity_Packages', '1.2.3f4', 'Unity.pkg')
+          end
         end
 
         it 'returns the custom destination for the specified package when the environment variable is specified' do
@@ -493,18 +495,19 @@ describe U3d do
 
       describe '.destination_for' do
         it 'returns the correct default destination the specified package' do
-          warn_if_env('U3D_DOWNLOAD_PATH')
-          expect(U3d::Utils).to receive(:ensure_dir) {}
-          allow(U3d::INIparser).to receive(:load_ini) { { 'package' => { 'url' => 'Windows64EditorInstaller/UnitySetup64.exe' } } }
+          with_env_values('U3D_DOWNLOAD_PATH' => nil) do
+            expect(U3d::Utils).to receive(:ensure_dir) {}
+            allow(U3d::INIparser).to receive(:load_ini) { { 'package' => { 'url' => 'Windows64EditorInstaller/UnitySetup64.exe' } } }
 
-          definition = U3d::UnityVersionDefinition.new('1.2.3f4', :win, nil)
+            definition = U3d::UnityVersionDefinition.new('1.2.3f4', :win, nil)
 
-          expect(
-            @downloader.destination_for(
-              'package',
-              definition
-            )
-          ).to eql File.join(ENV['HOME'], 'Downloads', 'Unity_Packages', '1.2.3f4', 'UnitySetup64.exe')
+            expect(
+              @downloader.destination_for(
+                'package',
+                definition
+              )
+            ).to eql File.join(ENV['HOME'], 'Downloads', 'Unity_Packages', '1.2.3f4', 'UnitySetup64.exe')
+          end
         end
 
         it 'returns the custom destination for the specified package when the environment variable is specified' do

--- a/spec/u3d/downloader_spec.rb
+++ b/spec/u3d/downloader_spec.rb
@@ -386,7 +386,7 @@ describe U3d do
       end
 
       describe '.destination_for' do
-        it 'returns the correct default destination for the specified package' do
+        it 'returns the correct default destination for the Unity installer' do
           warn_if_env('U3D_DOWNLOAD_PATH')
           expect(U3d::Utils).to receive(:ensure_dir) {}
           allow(U3d::INIparser).to receive(:load_ini) { { 'Unity' => { 'url' => 'http://download.unity3d.com/download_unity/linux/unity-editor-installer-1.2.3f4+20160628.sh' } } }
@@ -401,7 +401,7 @@ describe U3d do
           ).to eql File.join(ENV['HOME'], 'Downloads', 'Unity_Packages', '1.2.3f4', 'unity-editor-installer-1.2.3f4+20160628.sh')
         end
 
-        it 'returns the custom destination for the specified package when the environment variable is specified' do
+        it 'returns the custom destination for the Unity installer when the environment variable is specified' do
           with_env_values('U3D_DOWNLOAD_PATH' => '/foo') do
             expect(U3d::Utils).to receive(:ensure_dir) {}
             allow(U3d::INIparser).to receive(:load_ini) { { 'Unity' => { 'url' => 'http://download.unity3d.com/download_unity/linux/unity-editor-installer-1.2.3f4+20160628.sh' } } }

--- a/spec/u3d/downloader_spec.rb
+++ b/spec/u3d/downloader_spec.rb
@@ -386,7 +386,8 @@ describe U3d do
       end
 
       describe '.destination_for' do
-        it 'returns the correct destination the Unity installer' do
+        it 'returns the correct default destination for the specified package' do
+          warn_if_env('U3D_DOWNLOAD_PATH')
           expect(U3d::Utils).to receive(:ensure_dir) {}
           allow(U3d::INIparser).to receive(:load_ini) { { 'Unity' => { 'url' => 'http://download.unity3d.com/download_unity/linux/unity-editor-installer-1.2.3f4+20160628.sh' } } }
 
@@ -398,6 +399,22 @@ describe U3d do
               definition
             )
           ).to eql File.join(ENV['HOME'], 'Downloads', 'Unity_Packages', '1.2.3f4', 'unity-editor-installer-1.2.3f4+20160628.sh')
+        end
+
+        it 'returns the custom destination for the specified package when the environment variable is specified' do
+          with_env_values('U3D_DOWNLOAD_PATH' => '/foo') do
+            expect(U3d::Utils).to receive(:ensure_dir) {}
+            allow(U3d::INIparser).to receive(:load_ini) { { 'Unity' => { 'url' => 'http://download.unity3d.com/download_unity/linux/unity-editor-installer-1.2.3f4+20160628.sh' } } }
+
+            definition = U3d::UnityVersionDefinition.new('1.2.3f4', :linux, nil)
+
+            expect(
+              @downloader.destination_for(
+                'Unity',
+                definition
+              )
+            ).to eql File.join(File.expand_path('/foo'), '1.2.3f4', 'unity-editor-installer-1.2.3f4+20160628.sh')
+          end
         end
       end
 
@@ -422,7 +439,8 @@ describe U3d do
       end
 
       describe '.destination_for' do
-        it 'returns the correct destination the specified package' do
+        it 'returns the correct default destination for the specified package' do
+          warn_if_env('U3D_DOWNLOAD_PATH')
           expect(U3d::Utils).to receive(:ensure_dir) {}
           allow(U3d::INIparser).to receive(:load_ini) { { 'package' => { 'url' => 'MacEditorInstaller/Unity.pkg' } } }
 
@@ -434,6 +452,22 @@ describe U3d do
               definition
             )
           ).to eql File.join(ENV['HOME'], 'Downloads', 'Unity_Packages', '1.2.3f4', 'Unity.pkg')
+        end
+
+        it 'returns the custom destination for the specified package when the environment variable is specified' do
+          with_env_values('U3D_DOWNLOAD_PATH' => '/foo') do
+            expect(U3d::Utils).to receive(:ensure_dir) {}
+            allow(U3d::INIparser).to receive(:load_ini) { { 'package' => { 'url' => 'MacEditorInstaller/Unity.pkg' } } }
+
+            definition = U3d::UnityVersionDefinition.new('1.2.3f4', :mac, nil)
+
+            expect(
+              @downloader.destination_for(
+                'package',
+                definition
+              )
+            ).to eql File.join(File.expand_path('/foo'), '1.2.3f4', 'Unity.pkg')
+          end
         end
       end
 
@@ -458,7 +492,8 @@ describe U3d do
       end
 
       describe '.destination_for' do
-        it 'returns the correct destination the specified package' do
+        it 'returns the correct default destination the specified package' do
+          warn_if_env('U3D_DOWNLOAD_PATH')
           expect(U3d::Utils).to receive(:ensure_dir) {}
           allow(U3d::INIparser).to receive(:load_ini) { { 'package' => { 'url' => 'Windows64EditorInstaller/UnitySetup64.exe' } } }
 
@@ -470,6 +505,22 @@ describe U3d do
               definition
             )
           ).to eql File.join(ENV['HOME'], 'Downloads', 'Unity_Packages', '1.2.3f4', 'UnitySetup64.exe')
+        end
+
+        it 'returns the custom destination for the specified package when the environment variable is specified' do
+          with_env_values('U3D_DOWNLOAD_PATH' => '/foo') do
+            expect(U3d::Utils).to receive(:ensure_dir) {}
+            allow(U3d::INIparser).to receive(:load_ini) { { 'package' => { 'url' => 'Windows64EditorInstaller/UnitySetup64.exe' } } }
+
+            definition = U3d::UnityVersionDefinition.new('1.2.3f4', :win, nil)
+
+            expect(
+              @downloader.destination_for(
+                'package',
+                definition
+              )
+            ).to eql File.join(File.expand_path('/foo'), '1.2.3f4', 'UnitySetup64.exe')
+          end
         end
       end
 


### PR DESCRIPTION
This adds a new option to `u3d install` so that the user can specify the target of its destination.
`u3d install <SOME STUFF> --download_path <SOME PATH>` will download if not already present at specified path and install it from this file.
`u3d install <SOME STUFF> --no-install --download_path <SOME PATH>` will download packages at some location, and make sure that they don't already exist there.

This works for both absolute and relative paths.