### PR TITLE
u3d/internals: a serie of cache related refactors

### DIFF
--- a/lib/u3d/cache.rb
+++ b/lib/u3d/cache.rb
@@ -53,7 +53,7 @@ module U3d
 
     def initialize(path: nil, force_os: nil, force_refresh: false, offline: false)
       raise "Cache: cannot specify both offline and force_refresh" if offline && force_refresh
-      @path = path || default_path
+      @path = path || Cache.default_os_path
       @cache = {}
       os = force_os || U3dCore::Helper.operating_system
       Utils.ensure_dir(@path)
@@ -65,6 +65,17 @@ module U3d
       end
       @cache = data
       overwrite_cache(file_path, os) if need_update || force_refresh
+    end
+
+    def self.default_os_path
+      case U3dCore::Helper.operating_system
+      when :linux
+        DEFAULT_LINUX_PATH
+      when :mac
+        DEFAULT_MAC_PATH
+      when :win
+        DEFAULT_WINDOWS_PATH
+      end
     end
 
     private #-------------------------------------------------------------------
@@ -109,17 +120,6 @@ module U3d
       @cache[os.id2name]['versions'] = UnityVersions.list_available(os: os)
       File.delete(file_path) if File.file?(file_path)
       File.open(file_path, 'w') { |f| f.write(@cache.to_json) }
-    end
-
-    def default_path
-      case U3dCore::Helper.operating_system
-      when :linux
-        DEFAULT_LINUX_PATH
-      when :mac
-        DEFAULT_MAC_PATH
-      when :win
-        DEFAULT_WINDOWS_PATH
-      end
     end
   end
 end

--- a/lib/u3d/commands.rb
+++ b/lib/u3d/commands.rb
@@ -99,13 +99,6 @@ module U3d
         end
       end
 
-      def cache_versions(os, offline: false)
-        cache = Cache.new(force_os: os, offline: offline)
-        cache_os = cache[os.id2name] || {}
-        cache_versions = cache_os['versions'] || {}
-        cache_versions
-      end
-
       def install(args: [], options: {})
         version = specified_or_current_project_version(args[0])
 
@@ -224,6 +217,13 @@ module U3d
       end
 
       private
+
+      def cache_versions(os, offline: false)
+        cache = Cache.new(force_os: os, offline: offline)
+        cache_os = cache[os.id2name] || {}
+        cache_versions = cache_os['versions'] || {}
+        cache_versions
+      end
 
       def verify_package_names(definition, packages)
         packages.each do |package|

--- a/spec/u3d/commands_spec.rb
+++ b/spec/u3d/commands_spec.rb
@@ -99,6 +99,7 @@ describe U3d do
 
           expect(U3d::Cache).to receive(:new).with(
             force_os: :fakeos,
+            offline: false,
             force_refresh: true
           ) { { 'fakeos' => { 'versions' => {} } } }
 
@@ -135,7 +136,7 @@ describe U3d do
             expect(oses).to receive(:include?).with(fakeos_sym) { true }
             allow(fakeos_sym).to receive(:id2name) { 'fakeos' }
 
-            expect(U3d::Cache).to receive(:new).with(force_os: fakeos_sym, force_refresh: false) { { 'fakeos' => { 'versions' => {} } } }
+            expect(U3d::Cache).to receive(:new).with(force_os: fakeos_sym, offline: false, force_refresh: false) { { 'fakeos' => { 'versions' => {} } } }
 
             U3d::Commands.list_available(options: { operating_system: fakeos, force: false })
           end
@@ -154,7 +155,7 @@ describe U3d do
 
           it 'assumes the OS if nothing specified' do
             expect(U3d::Helper).to receive(:operating_system) { :fakeos }
-            expect(U3d::Cache).to receive(:new).with(force_os: :fakeos, force_refresh: false) { { 'fakeos' => { 'versions' => {} } } }
+            expect(U3d::Cache).to receive(:new).with(force_os: :fakeos, offline: false, force_refresh: false) { { 'fakeos' => { 'versions' => {} } } }
 
             U3d::Commands.list_available(options: { force: false })
           end


### PR DESCRIPTION
* enable to access cache pass from a class method
* hide a method private
* reuse cache_versions in commands.available as to have a single place where we instantiate the Cache class