### PR TITLE
u3d/available: introduce a central cache (fixes #142)

### DIFF
--- a/lib/u3d/cache.rb
+++ b/lib/u3d/cache.rb
@@ -22,12 +22,15 @@
 
 require 'json'
 require 'time'
+require 'u3d_core/core_ext/operating_system_symbol'
 require 'u3d/unity_versions'
 require 'u3d/utils'
 
 module U3d
   # Cache stores the informations regarding versions
   class Cache
+    using ::CoreExtensions::OperatingSystem
+
     # Path to the directory containing the cache for the different OS
     DEFAULT_LINUX_PATH = File.join(ENV['HOME'], '.u3d').freeze
     DEFAULT_MAC_PATH = File.join(ENV['HOME'], 'Library', 'Application Support', 'u3d').freeze
@@ -134,10 +137,7 @@ module U3d
     end
 
     def update_cache(os)
-      platform = 'Windows' if os == :win
-      platform = 'Mac OSX' if os == :mac
-      platform = 'Linux' if os == :linux
-      UI.important "Cache is out of date. Updating cache for #{platform}"
+      UI.important "Cache is out of date. Updating cache for #{os.human_name}"
 
       @cache ||= {}
       @cache[os.id2name] = {}

--- a/lib/u3d/commands.rb
+++ b/lib/u3d/commands.rb
@@ -220,7 +220,7 @@ module U3d
       private
 
       def cache_versions(os, offline: false, force_refresh: false)
-        cache = Cache.new(force_os: os, offline: offline, force_refresh: force_refresh)
+        cache = Cache.new(force_os: os, offline: offline, force_refresh: force_refresh, central_cache: true)
         cache_os = cache[os.id2name] || {}
         cache_versions = cache_os['versions'] || {}
         cache_versions

--- a/lib/u3d_core/core_ext/operating_system_symbol.rb
+++ b/lib/u3d_core/core_ext/operating_system_symbol.rb
@@ -1,0 +1,33 @@
+## --- BEGIN LICENSE BLOCK ---
+# Copyright (c) 2017-present WeWantToKnow AS
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+## --- END LICENSE BLOCK ---
+module CoreExtensions
+  module OperatingSystem
+    refine Symbol do
+      def human_name
+        return 'Windows' if self == :win
+        return 'Mac OSX' if self == :mac
+        return 'Linux' if self == :linux
+        raise "Not a known operating system symbol #{self}"
+      end
+    end
+  end
+end

--- a/spec/u3d/commands_spec.rb
+++ b/spec/u3d/commands_spec.rb
@@ -100,7 +100,8 @@ describe U3d do
           expect(U3d::Cache).to receive(:new).with(
             force_os: :fakeos,
             offline: false,
-            force_refresh: true
+            force_refresh: true,
+            central_cache: true
           ) { { 'fakeos' => { 'versions' => {} } } }
 
           U3d::Commands.list_available(options: { force: true })
@@ -145,7 +146,7 @@ describe U3d do
             expect(oses).to receive(:include?).with(fakeos_sym) { true }
             allow(fakeos_sym).to receive(:id2name) { 'fakeos' }
 
-            expect(U3d::Cache).to receive(:new).with(force_os: fakeos_sym, offline: false, force_refresh: false) { { 'fakeos' => { 'versions' => {} } } }
+            expect(U3d::Cache).to receive(:new).with(force_os: fakeos_sym, offline: false, force_refresh: false, central_cache: true) { { 'fakeos' => { 'versions' => {} } } }
 
             U3d::Commands.list_available(options: { operating_system: fakeos, force: false })
           end
@@ -164,7 +165,7 @@ describe U3d do
 
           it 'assumes the OS if nothing specified' do
             expect(U3d::Helper).to receive(:operating_system) { :fakeos }
-            expect(U3d::Cache).to receive(:new).with(force_os: :fakeos, offline: false, force_refresh: false) { { 'fakeos' => { 'versions' => {} } } }
+            expect(U3d::Cache).to receive(:new).with(force_os: :fakeos, offline: false, force_refresh: false, central_cache: true) { { 'fakeos' => { 'versions' => {} } } }
 
             U3d::Commands.list_available(options: { force: false })
           end


### PR DESCRIPTION
This is meant to fix #142.

Note that I haven't yet tested how this impacts the Linux version, as the Linux version normally creates the fake ini file as part of the discovering procedure

This depends on #215 and #216 and will need a rebase.
  