### PR TITLE
u3d/available: more regex support

### DIFF
--- a/lib/u3d/commands.rb
+++ b/lib/u3d/commands.rb
@@ -72,7 +72,7 @@ module U3d
         cache_versions = cache_versions(os, force_refresh: options[:force])
 
         if ver
-          cache_versions = cache_versions.extract(*cache_versions.keys.select { |k| /#{Regexp.quote(ver)}/.match(k) })
+          cache_versions = cache_versions.extract(*cache_versions.keys.select { |k| Regexp.new(ver).match(k) })
           return UI.error "Version #{ver} doesn't match any in cache" if cache_versions.empty?
         end
 

--- a/spec/u3d/commands_spec.rb
+++ b/spec/u3d/commands_spec.rb
@@ -118,7 +118,7 @@ describe U3d do
           U3d::Commands.list_available(options: { unity_version: 'not.a.version' })
         end
 
-        it 'only logs specified version' do
+        it 'only logs specified version using fully described version' do
           on_fake_os
           with_fake_cache('fakeos' => { 'versions' => { '1.2.3f4' => 'fakeurl' } })
 
@@ -127,7 +127,7 @@ describe U3d do
           U3d::Commands.list_available(options: { unity_version: '1.2.3f4' })
         end
 
-        it 'only logs specified version found using regular expression' do
+        it 'only logs specified version found using partial version' do
           on_fake_os
           with_fake_cache('fakeos' => { 'versions' => { '1.2.3f4' => 'fakeurl', '1.3.3f4' => 'fakeurl' } })
 
@@ -135,6 +135,15 @@ describe U3d do
 
           U3d::Commands.list_available(options: { unity_version: '1.2' })
         end
+
+        it 'only logs specified version found using regular expression' do
+            on_fake_os
+            with_fake_cache('fakeos' => { 'versions' => { '1.2.3f4' => 'fakeurl', '1.3.3f4' => 'fakeurl' } })
+  
+            expect(U3d::UI).to receive(:message).with(/.*1.2.3f4.*fakeurl.*/)
+  
+            U3d::Commands.list_available(options: { unity_version: '1\.2\..+' })
+          end
 
         context 'when parsing user OS input' do
           it 'uses correct input' do

--- a/spec/u3d/commands_spec.rb
+++ b/spec/u3d/commands_spec.rb
@@ -137,13 +137,13 @@ describe U3d do
         end
 
         it 'only logs specified version found using regular expression' do
-            on_fake_os
-            with_fake_cache('fakeos' => { 'versions' => { '1.2.3f4' => 'fakeurl', '1.3.3f4' => 'fakeurl' } })
-  
-            expect(U3d::UI).to receive(:message).with(/.*1.2.3f4.*fakeurl.*/)
-  
-            U3d::Commands.list_available(options: { unity_version: '1\.2\..+' })
-          end
+          on_fake_os
+          with_fake_cache('fakeos' => { 'versions' => { '1.2.3f4' => 'fakeurl', '1.3.3f4' => 'fakeurl' } })
+
+          expect(U3d::UI).to receive(:message).with(/.*1.2.3f4.*fakeurl.*/)
+
+          U3d::Commands.list_available(options: { unity_version: '1\.2\..+' })
+        end
 
         context 'when parsing user OS input' do
           it 'uses correct input' do


### PR DESCRIPTION
This make it so that `-u` supports regular expression such as `2017\.*`,  `5\..\.0.+`...