### PR TITLE
u3d/install Unity 2018. Download works on Windows and Mac and Mac installs. Fixes #225

### DIFF
--- a/lib/u3d/commands.rb
+++ b/lib/u3d/commands.rb
@@ -103,7 +103,8 @@ module U3d
       def install(args: [], options: {})
         version = specified_or_current_project_version(args[0])
 
-        os = U3dCore::Helper.operating_system
+        UI.user_error!("install can only work with current operating system. You specified #{options[:operating_system]}") if options[:install] && options[:operating_system]
+        os = valid_os_or_current(options[:operating_system])
 
         packages = packages_with_unity_first(os, options)
 

--- a/lib/u3d/commands_generator.rb
+++ b/lib/u3d/commands_generator.rb
@@ -122,7 +122,8 @@ Fore more information about how the rules work, see https://github.com/DragonBox
       end
 
       command :install do |c|
-        c.syntax = 'u3d install [<version>] [ [-p | --packages <package1>,<package2> ...] | [-a | --all] ] [--[no-]download] [ [--[no-]install] [-i | --installation_path <path>] ]'
+        oses = U3dCore::Helper.operating_systems
+        c.syntax = 'u3d install [<version>] [ [-p | --packages <package1>,<package2> ...] | [-o | --operating_system <OS>] [-a | --all] ] [--[no-]download] [ [--[no-]install] [-i | --installation_path <path>] ]'
         c.summary = "Download (and/or) install Unity3D editor packages."
         c.description = %(
 #{c.summary}
@@ -139,10 +140,12 @@ E.g. U3D_DOWNLOAD_PATH=/some/path/you/want u3d install ...
         c.option '--[no-]download', 'Perform or not downloading before installation. Downloads by default'
         c.option '--[no-]install', 'Perform or not installation after downloading. Installs by default'
         c.option '-p', '--packages PACKAGES', Array, 'Specifies which packages to download/install. Overriden by --all'
+        c.option '-o', '--operating_system STRING', String, "Checks for availability on specific OS [#{oses.join(', ')}]"
         c.option '-a', '--all', 'Download all available packages. Overrides -p'
         c.option '-i', '--installation_path PATH', String, 'Specifies where package(s) will be downloaded/installed. Conflicts with --no-install'
         c.option '-k', '--keychain', 'Gain privileges right through the keychain. [OSX only]'
         c.example 'Download and install Unity, its Documentation and the Android build support and install them for version 5.1.2f1', 'u3d install 5.1.2f1 -p Unity,Documentation,Android'
+        c.example 'Download but do not install all Unity version 2018.1.0b2 packages for platform Windows (while e.g. on Mac)', 'u3d install 2018.1.0b2 -o win -a --no-install'
         c.example "The 'version' argument can be a specific version number, such as 5.6.1f1, or an alias in [#{Commands.release_letter_mapping.keys.join(', ')}]. If not specified, u3d will download the unity version for the current project", 'u3d install latest'
         c.example "The admin password can be passed through the U3D_PASSWORD environment variable.", 'U3D_PASSWORD=mysecret u3d install a_version'
         c.example "On Mac, the admin password can be fetched from (and stored into) the keychain.", 'u3d install -k a_version'

--- a/lib/u3d/download_validator.rb
+++ b/lib/u3d/download_validator.rb
@@ -66,6 +66,11 @@ module U3d
 
   class WindowsValidator < DownloadValidator
     def validate(package, file, definition)
+      # External packages have no md5 and a false size value
+      if definition[package]['size'] % 1000 && definition[package]['md5'].nil?
+        UI.verbose "File '#{definition[package]['title']}' seems external. Validation skipped"
+        return true
+      end
       rounded_size = (File.size(file).to_f / 1024).floor
       size_validation(expected: definition[package]['size'], actual: rounded_size) &&
         hash_validation(expected: definition[package]['md5'], actual: Utils.hashfile(file))

--- a/spec/u3d/downloader_spec.rb
+++ b/spec/u3d/downloader_spec.rb
@@ -383,13 +383,15 @@ describe U3d do
     describe U3d::Downloader::LinuxDownloader do
       before(:all) do
         @downloader = U3d::Downloader::LinuxDownloader.new
+        @url = 'http://download.unity3d.com/download_unity/linux/unity-editor-installer-1.2.3f4+20160628.sh'
       end
 
       describe '.destination_for' do
         it 'returns the correct default destination for the Unity installer' do
           with_env_values('U3D_DOWNLOAD_PATH' => nil) do
+            expect(U3d::Utils).to receive(:final_url).with(@url).and_return(@url)
             expect(U3d::Utils).to receive(:ensure_dir) {}
-            allow(U3d::INIparser).to receive(:load_ini) { { 'Unity' => { 'url' => 'http://download.unity3d.com/download_unity/linux/unity-editor-installer-1.2.3f4+20160628.sh' } } }
+            allow(U3d::INIparser).to receive(:load_ini) { { 'Unity' => { 'url' => @url } } }
 
             definition = U3d::UnityVersionDefinition.new('1.2.3f4', :linux, nil)
 
@@ -404,8 +406,9 @@ describe U3d do
 
         it 'returns the custom destination for the Unity installer when the environment variable is specified' do
           with_env_values('U3D_DOWNLOAD_PATH' => '/foo') do
+            expect(U3d::Utils).to receive(:final_url).with(@url).and_return(@url)
             expect(U3d::Utils).to receive(:ensure_dir) {}
-            allow(U3d::INIparser).to receive(:load_ini) { { 'Unity' => { 'url' => 'http://download.unity3d.com/download_unity/linux/unity-editor-installer-1.2.3f4+20160628.sh' } } }
+            allow(U3d::INIparser).to receive(:load_ini) { { 'Unity' => { 'url' => @url } } }
 
             definition = U3d::UnityVersionDefinition.new('1.2.3f4', :linux, nil)
 
@@ -421,15 +424,16 @@ describe U3d do
 
       describe '.url_for' do
         it 'returns the correct url for the Unity installer' do
-          allow(U3d::INIparser).to receive(:load_ini) { { 'Unity' => { 'url' => 'http://download.unity3d.com/download_unity/linux/unity-editor-installer-1.2.3f4+20160628.sh' } } }
+          expect(U3d::Utils).to receive(:final_url).with(@url).and_return(@url)
+          allow(U3d::INIparser).to receive(:load_ini) { { 'Unity' => { 'url' => @url } } }
 
-          definition = U3d::UnityVersionDefinition.new('1.2.3f4', :linux, '1.2.3f4' => 'http://download.unity3d.com/download_unity/linux/unity-editor-installer-1.2.3f4+20160628.sh')
+          definition = U3d::UnityVersionDefinition.new('1.2.3f4', :linux, '1.2.3f4' => @url)
           expect(
             @downloader.url_for(
               'Unity',
               definition
             )
-          ).to eql 'http://download.unity3d.com/download_unity/linux/unity-editor-installer-1.2.3f4+20160628.sh'
+          ).to eql @url
         end
       end
     end
@@ -437,15 +441,19 @@ describe U3d do
     describe U3d::Downloader::MacDownloader do
       before(:all) do
         @downloader = U3d::Downloader::MacDownloader.new
+
+        @url = 'http://download.unity3d.com/download_unity/d3101c3b8468/'
+        @path = 'MacEditorInstaller/Unity.pkg'
+        @final_url = "#{@url}#{@path}"
       end
 
       describe '.destination_for' do
         it 'returns the correct default destination for the specified package' do
           with_env_values('U3D_DOWNLOAD_PATH' => nil) do
             expect(U3d::Utils).to receive(:ensure_dir) {}
-            allow(U3d::INIparser).to receive(:load_ini) { { 'package' => { 'url' => 'MacEditorInstaller/Unity.pkg' } } }
+            allow(U3d::INIparser).to receive(:load_ini) { { 'package' => { 'url' => @path } } }
 
-            definition = U3d::UnityVersionDefinition.new('1.2.3f4', :mac, nil)
+            definition = U3d::UnityVersionDefinition.new('1.2.3f4', :mac, '1.2.3f4' => @url)
 
             expect(
               @downloader.destination_for(
@@ -459,9 +467,9 @@ describe U3d do
         it 'returns the custom destination for the specified package when the environment variable is specified' do
           with_env_values('U3D_DOWNLOAD_PATH' => '/foo') do
             expect(U3d::Utils).to receive(:ensure_dir) {}
-            allow(U3d::INIparser).to receive(:load_ini) { { 'package' => { 'url' => 'MacEditorInstaller/Unity.pkg' } } }
+            allow(U3d::INIparser).to receive(:load_ini) { { 'package' => { 'url' => @path } } }
 
-            definition = U3d::UnityVersionDefinition.new('1.2.3f4', :mac, nil)
+            definition = U3d::UnityVersionDefinition.new('1.2.3f4', :mac, '1.2.3f4' => @url)
 
             expect(
               @downloader.destination_for(
@@ -475,15 +483,15 @@ describe U3d do
 
       describe '.url_for' do
         it 'returns the correct url for the specified package' do
-          allow(U3d::INIparser).to receive(:load_ini) { { 'package' => { 'url' => 'MacEditorInstaller/Unity.pkg' } } }
+          allow(U3d::INIparser).to receive(:load_ini) { { 'package' => { 'url' => @path } } }
 
-          definition = U3d::UnityVersionDefinition.new('1.2.3f4', :mac, '1.2.3f4' => 'http://download.unity3d.com/download_unity/d3101c3b8468/')
+          definition = U3d::UnityVersionDefinition.new('1.2.3f4', :mac, '1.2.3f4' => @url)
           expect(
             @downloader.url_for(
               'package',
               definition
             )
-          ).to eql 'http://download.unity3d.com/download_unity/d3101c3b8468/MacEditorInstaller/Unity.pkg'
+          ).to eql @final_url
         end
       end
     end
@@ -491,15 +499,18 @@ describe U3d do
     describe U3d::Downloader::WindowsDownloader do
       before(:all) do
         @downloader = U3d::Downloader::WindowsDownloader.new
+        @url = 'http://download.unity3d.com/download_unity/d3101c3b8468/'
+        @path = 'Windows64EditorInstaller/UnitySetup64.exe'
+        @final_url = "#{@url}#{@path}"
       end
 
       describe '.destination_for' do
         it 'returns the correct default destination the specified package' do
           with_env_values('U3D_DOWNLOAD_PATH' => nil) do
             expect(U3d::Utils).to receive(:ensure_dir) {}
-            allow(U3d::INIparser).to receive(:load_ini) { { 'package' => { 'url' => 'Windows64EditorInstaller/UnitySetup64.exe' } } }
+            allow(U3d::INIparser).to receive(:load_ini) { { 'package' => { 'url' => @path } } }
 
-            definition = U3d::UnityVersionDefinition.new('1.2.3f4', :win, nil)
+            definition = U3d::UnityVersionDefinition.new('1.2.3f4', :win, '1.2.3f4' => @url)
 
             expect(
               @downloader.destination_for(
@@ -513,9 +524,9 @@ describe U3d do
         it 'returns the custom destination for the specified package when the environment variable is specified' do
           with_env_values('U3D_DOWNLOAD_PATH' => '/foo') do
             expect(U3d::Utils).to receive(:ensure_dir) {}
-            allow(U3d::INIparser).to receive(:load_ini) { { 'package' => { 'url' => 'Windows64EditorInstaller/UnitySetup64.exe' } } }
+            allow(U3d::INIparser).to receive(:load_ini) { { 'package' => { 'url' => @path } } }
 
-            definition = U3d::UnityVersionDefinition.new('1.2.3f4', :win, nil)
+            definition = U3d::UnityVersionDefinition.new('1.2.3f4', :win, '1.2.3f4' => @url)
 
             expect(
               @downloader.destination_for(
@@ -529,15 +540,15 @@ describe U3d do
 
       describe '.url_for' do
         it 'returns the correct url for the specified package' do
-          allow(U3d::INIparser).to receive(:load_ini) { { 'package' => { 'url' => 'Windows64EditorInstaller/UnitySetup64.exe' } } }
+          allow(U3d::INIparser).to receive(:load_ini) { { 'package' => { 'url' => @path } } }
 
-          definition = U3d::UnityVersionDefinition.new('1.2.3f4', :win, '1.2.3f4' => 'http://download.unity3d.com/download_unity/d3101c3b8468/')
+          definition = U3d::UnityVersionDefinition.new('1.2.3f4', :win, '1.2.3f4' => @url)
           expect(
             @downloader.url_for(
               'package',
               definition
             )
-          ).to eql 'http://download.unity3d.com/download_unity/d3101c3b8468/Windows64EditorInstaller/UnitySetup64.exe'
+          ).to eql @final_url
         end
       end
     end


### PR DESCRIPTION
Statuses:

* downloader appears to work for both Windows and Mac (builds on #226)
* install works on Mac, so no regression here.
* EULA is not dealt with
* installation on Windows should probably reuse the new cmd information in the .ini file
* tests missing...