### PR TITLE
u3d/install: add support for installing .msi packages on Windows

### DIFF
--- a/lib/u3d/downloader.rb
+++ b/lib/u3d/downloader.rb
@@ -31,7 +31,7 @@ module U3d
     # Path to the directory for the package downloading
     DOWNLOAD_PATH = "#{ENV['HOME']}/Downloads".freeze
     # Regex to get the name of a package out of its file name
-    UNITY_MODULE_FILE_REGEX = %r{\/([\w\-_\.\+]+\.(?:pkg|exe|zip|sh|deb))}
+    UNITY_MODULE_FILE_REGEX = %r{\/([\w\-_\.\+]+\.(?:pkg|exe|zip|sh|deb|msi))[^\/]*$}
 
     class << self
       def download_directory

--- a/lib/u3d/installer.rb
+++ b/lib/u3d/installer.rb
@@ -305,14 +305,14 @@ module U3d
 
     def install_exe(file_path, installation_path: nil, info: {})
       installation_path ||= DEFAULT_WINDOWS_INSTALL
-      final_path = installation_path.tr('/', '\\')
+      final_path = Utils.windows_path(installation_path)
       Utils.ensure_dir(final_path)
       begin
         command = nil
         if info['cmd']
           command = info['cmd']
           if /msiexec/ =~ command
-            command.sub!(/{FILENAME}/, Utils.windows_path(file_path))
+            command.sub!(/{FILENAME}/, '"' + Utils.windows_path(file_path) + '"')
           else
             command.sub!(/{FILENAME}/, file_path)
           end

--- a/lib/u3d/installer.rb
+++ b/lib/u3d/installer.rb
@@ -312,7 +312,7 @@ module U3d
         if info['cmd']
           command = info['cmd']
           if /msiexec/ =~ command
-            command.sub!(/{FILENAME}/, '"' + file_path.gsub(%r{\/(\d)}, '/\\\\\1').tr('/', '\\') + '"')
+            command.sub!(/{FILENAME}/, Utils.windows_path(file_path))
           else
             command.sub!(/{FILENAME}/, file_path)
           end

--- a/lib/u3d/installer.rb
+++ b/lib/u3d/installer.rb
@@ -294,7 +294,7 @@ module U3d
 
     def install(file_path, version, installation_path: nil, info: {})
       extension = File.extname(file_path)
-      raise "Installation of #{extension} files is not supported on Windows" if !(extension == '.exe' || extension == '.msi')
+      raise "Installation of #{extension} files is not supported on Windows" unless %w[.exe .msi].include? extension
       path = installation_path || File.join(DEFAULT_WINDOWS_INSTALL, format(UNITY_DIR, version: version))
       install_exe(
         file_path,
@@ -311,10 +311,11 @@ module U3d
         command = nil
         if info['cmd']
           command = info['cmd']
-          command.sub!(/{FILENAME}/, (%r{msiexec} =~ command ?
-            '"' + file_path.gsub(/\/(\d)/, '/\\\\\1').gsub('/', '\\') + '"' : 
-            file_path
-          ))
+          if /msiexec/ =~ command
+            command.sub!(/{FILENAME}/, '"' + file_path.gsub(%r{\/(\d)}, '/\\\\\1').tr('/', '\\') + '"')
+          else
+            command.sub!(/{FILENAME}/, file_path)
+          end
           command.sub!(/{INSTDIR}/, final_path)
           command.sub!(/{DOCDIR}/, final_path)
           command.sub!(/{MODULEDIR}/, final_path)

--- a/lib/u3d/utils.rb
+++ b/lib/u3d/utils.rb
@@ -192,6 +192,10 @@ module U3d
       def pretty_filesize(filesize)
         Filesize.from(filesize.round.to_s + ' B').pretty
       end
+
+      def windows_path(path)
+        '"' + path.gsub(%r{\/(\d)}, '/\\\\\1').tr('/', '\\') + '"'
+      end
     end
   end
   # rubocop:enable ModuleLength

--- a/lib/u3d/utils.rb
+++ b/lib/u3d/utils.rb
@@ -194,7 +194,7 @@ module U3d
       end
 
       def windows_path(path)
-        '"' + path.gsub(%r{\/(\d)}, '/\\\\\1').tr('/', '\\') + '"'
+        path.gsub(%r{\/(\d)}, '/\\\\\1').tr('/', '\\')
       end
     end
   end


### PR DESCRIPTION
This adds support for downloading and installing .msi packages for Windows.