### PR TITLE
u3d/install: improve messages

### DIFF
--- a/lib/u3d/installer.rb
+++ b/lib/u3d/installer.rb
@@ -63,7 +63,7 @@ module U3d
     def self.install_modules(files, version, installation_path: nil)
       installer = Installer.create
       files.each do |name, file, info|
-        UI.header "Installing #{name}"
+        UI.header "Installing #{info['title']} (#{name})"
         UI.message 'Installing with ' + file
         installer.install(file, version, installation_path: installation_path, info: info)
       end

--- a/lib/u3d/installer.rb
+++ b/lib/u3d/installer.rb
@@ -63,7 +63,8 @@ module U3d
     def self.install_modules(files, version, installation_path: nil)
       installer = Installer.create
       files.each do |name, file, info|
-        UI.verbose "Installing #{name}#{info['mandatory'] ? ' (mandatory package)' : ''}, with file #{file}"
+        UI.header "Installing #{name}"
+        UI.message 'Installing with ' + file
         installer.install(file, version, installation_path: installation_path, info: info)
       end
     end


### PR DESCRIPTION
This improves the output of the installer by making it more obvious what is happening, and make it similar to the downloader output.