### PR TITLE
u3d/prettify: Fix rule termination when there are special characters in the file name

### DIFF
--- a/config/log_rules.json
+++ b/config/log_rules.json
@@ -11,7 +11,7 @@
       "fail": {
         "active": true,
         "start_pattern": "^(?<fail>Failed to .+)\\n",
-        "end_pattern": "Filename: (?:[\\w/:\\.\\s-_]+/(?<file>\\w+\\.\\w+))? Line: (?<line>-?\\d+)",
+        "end_pattern": "Filename: (?:.+/(?<file>\\w+\\.\\w+))? Line: (?<line>-?\\d+)",
         "start_message": false,
         "end_message": "%{file}(line %{line}): %{fail}",
         "store_lines": false,
@@ -39,7 +39,7 @@
       "exception_report": {
         "active": true,
         "start_pattern": "^(?<message>.*threw exception\\.)\\n",
-        "end_pattern": "Filename: (?:[\\w/:\\.\\s-_]+/(?<file>\\w+\\.\\w+))? Line: (?<line>-?\\d+)",
+        "end_pattern": "Filename: (?:.+/(?<file>\\w+\\.\\w+))? Line: (?<line>-?\\d+)",
         "start_message": false,
         "end_message": "%{file}(line %{line}): %{message}",
         "store_lines": false,
@@ -74,7 +74,7 @@
         "fetched_line_pattern": "(?<message>.*)\\n",
         "fetched_line_message": false,
         "start_message": false,
-        "end_pattern": "Filename: (?:[\\w/:\\.\\s-_]+/(?<file>\\w+\\.\\w+))? Line: (?<line>-?\\d+)",
+        "end_pattern": "Filename: (?:.+/(?<file>\\w+\\.\\w+))? Line: (?<line>-?\\d+)",
         "end_message": "[LOG] %{file}(line %{line}): %{message}",
         "type": "warning"
       },
@@ -89,7 +89,7 @@
         "fetched_line_pattern": "(?<message>.*)\\n",
         "fetched_line_message": false,
         "start_message": false,
-        "end_pattern": "Filename: (?:[\\w/:\\.\\s-_]+/(?<file>\\w+\\.\\w+))? Line: (?<line>-?\\d+)",
+        "end_pattern": "Filename: (?:.+/(?<file>\\w+\\.\\w+))? Line: (?<line>-?\\d+)",
         "end_message": "[LOG] %{file}(line %{line}): %{message}",
         "type": "warning"
       },
@@ -105,7 +105,7 @@
         "fetched_line_pattern": "(?<message>.*)\\n",
         "fetched_line_message": false,
         "start_message": false,
-        "end_pattern": "Filename: (?:[\\w/:\\.\\s-_]+/(?<file>\\w+\\.\\w+))? Line: (?<line>-?\\d+)",
+        "end_pattern": "Filename: (?:.+/(?<file>\\w+\\.\\w+))? Line: (?<line>-?\\d+)",
         "end_message": "[LOG] %{file}(line %{line}): %{message}",
         "type": "error"
       },
@@ -121,7 +121,7 @@
         "fetched_line_pattern": "(?<message>.*)\\n",
         "fetched_line_message": false,
         "start_message": false,
-        "end_pattern": "Filename: (?:[\\w/:\\.\\s-_]+/(?<file>\\w+\\.\\w+))? Line: (?<line>-?\\d+)",
+        "end_pattern": "Filename: (?:.+/(?<file>\\w+\\.\\w+))? Line: (?<line>-?\\d+)",
         "end_message": "[LOG] %{file}(line %{line}): %{message}",
         "type": "error"
       },
@@ -341,7 +341,7 @@
       "command_invocation_failure_stack": {
         "active": true,
         "start_pattern": "[Ee]xit code: (?<code>\\d+)",
-        "end_pattern": "Filename: (?:[\\w/:]+/(?<file>\\w+\\.\\w+))? Line: (?<line>-?\\d+)",
+        "end_pattern": "Filename: (?:.+/(?<file>\\w+\\.\\w+))? Line: (?<line>-?\\d+)",
         "start_message": false,
         "end_message": "[ANDROID] %{file}(line %{line}) Exit code %{code}"
       }

--- a/config/log_rules.json
+++ b/config/log_rules.json
@@ -11,7 +11,7 @@
       "fail": {
         "active": true,
         "start_pattern": "^(?<fail>Failed to .+)\\n",
-        "end_pattern": "Filename: (?:[\\w/:\\.]+/(?<file>\\w+\\.\\w+))? Line: (?<line>-?\\d+)",
+        "end_pattern": "Filename: (?:[\\w/:\\.\\s-_]+/(?<file>\\w+\\.\\w+))? Line: (?<line>-?\\d+)",
         "start_message": false,
         "end_message": "%{file}(line %{line}): %{fail}",
         "store_lines": false,
@@ -39,7 +39,7 @@
       "exception_report": {
         "active": true,
         "start_pattern": "^(?<message>.*threw exception\\.)\\n",
-        "end_pattern": "Filename: (?:[\\w/:\\.]+/(?<file>\\w+\\.\\w+))? Line: (?<line>-?\\d+)",
+        "end_pattern": "Filename: (?:[\\w/:\\.\\s-_]+/(?<file>\\w+\\.\\w+))? Line: (?<line>-?\\d+)",
         "start_message": false,
         "end_message": "%{file}(line %{line}): %{message}",
         "store_lines": false,
@@ -74,7 +74,7 @@
         "fetched_line_pattern": "(?<message>.*)\\n",
         "fetched_line_message": false,
         "start_message": false,
-        "end_pattern": "Filename: (?:[\\w/:\\.]+/(?<file>\\w+\\.\\w+))? Line: (?<line>-?\\d+)",
+        "end_pattern": "Filename: (?:[\\w/:\\.\\s-_]+/(?<file>\\w+\\.\\w+))? Line: (?<line>-?\\d+)",
         "end_message": "[LOG] %{file}(line %{line}): %{message}",
         "type": "warning"
       },
@@ -89,7 +89,7 @@
         "fetched_line_pattern": "(?<message>.*)\\n",
         "fetched_line_message": false,
         "start_message": false,
-        "end_pattern": "Filename: (?:[\\w/:\\.]+/(?<file>\\w+\\.\\w+))? Line: (?<line>-?\\d+)",
+        "end_pattern": "Filename: (?:[\\w/:\\.\\s-_]+/(?<file>\\w+\\.\\w+))? Line: (?<line>-?\\d+)",
         "end_message": "[LOG] %{file}(line %{line}): %{message}",
         "type": "warning"
       },
@@ -105,7 +105,7 @@
         "fetched_line_pattern": "(?<message>.*)\\n",
         "fetched_line_message": false,
         "start_message": false,
-        "end_pattern": "Filename: (?:[\\w/:\\.]+/(?<file>\\w+\\.\\w+))? Line: (?<line>-?\\d+)",
+        "end_pattern": "Filename: (?:[\\w/:\\.\\s-_]+/(?<file>\\w+\\.\\w+))? Line: (?<line>-?\\d+)",
         "end_message": "[LOG] %{file}(line %{line}): %{message}",
         "type": "error"
       },
@@ -121,7 +121,7 @@
         "fetched_line_pattern": "(?<message>.*)\\n",
         "fetched_line_message": false,
         "start_message": false,
-        "end_pattern": "Filename: (?:[\\w/:\\.]+/(?<file>\\w+\\.\\w+))? Line: (?<line>-?\\d+)",
+        "end_pattern": "Filename: (?:[\\w/:\\.\\s-_]+/(?<file>\\w+\\.\\w+))? Line: (?<line>-?\\d+)",
         "end_message": "[LOG] %{file}(line %{line}): %{message}",
         "type": "error"
       },

--- a/config/log_rules.json
+++ b/config/log_rules.json
@@ -11,7 +11,7 @@
       "fail": {
         "active": true,
         "start_pattern": "^(?<fail>Failed to .+)\\n",
-        "end_pattern": "Filename: (?:[\\w/:]+/(?<file>\\w+\\.\\w+))? Line: (?<line>-?\\d+)",
+        "end_pattern": "Filename: (?:[\\w/:\\.]+/(?<file>\\w+\\.\\w+))? Line: (?<line>-?\\d+)",
         "start_message": false,
         "end_message": "%{file}(line %{line}): %{fail}",
         "store_lines": false,
@@ -39,7 +39,7 @@
       "exception_report": {
         "active": true,
         "start_pattern": "^(?<message>.*threw exception\\.)\\n",
-        "end_pattern": "Filename: (?:[\\w/:]+/(?<file>\\w+\\.\\w+))? Line: (?<line>-?\\d+)",
+        "end_pattern": "Filename: (?:[\\w/:\\.]+/(?<file>\\w+\\.\\w+))? Line: (?<line>-?\\d+)",
         "start_message": false,
         "end_message": "%{file}(line %{line}): %{message}",
         "store_lines": false,
@@ -74,7 +74,7 @@
         "fetched_line_pattern": "(?<message>.*)\\n",
         "fetched_line_message": false,
         "start_message": false,
-        "end_pattern": "Filename: (?:[\\w/:]+/(?<file>\\w+\\.\\w+))? Line: (?<line>-?\\d+)",
+        "end_pattern": "Filename: (?:[\\w/:\\.]+/(?<file>\\w+\\.\\w+))? Line: (?<line>-?\\d+)",
         "end_message": "[LOG] %{file}(line %{line}): %{message}",
         "type": "warning"
       },
@@ -83,12 +83,13 @@
         "start_pattern": "UnityEngine\\.Debug:LogWarning\\(Object\\)",
         "fetch_first_line_not_matching": [
           "UnityEngine\\.",
-          "^\\n"
+          "^\\n",
+          "^\\s+"
         ],
         "fetched_line_pattern": "(?<message>.*)\\n",
         "fetched_line_message": false,
         "start_message": false,
-        "end_pattern": "Filename: (?:[\\w/:]+/(?<file>\\w+\\.\\w+))? Line: (?<line>-?\\d+)",
+        "end_pattern": "Filename: (?:[\\w/:\\.]+/(?<file>\\w+\\.\\w+))? Line: (?<line>-?\\d+)",
         "end_message": "[LOG] %{file}(line %{line}): %{message}",
         "type": "warning"
       },
@@ -104,7 +105,7 @@
         "fetched_line_pattern": "(?<message>.*)\\n",
         "fetched_line_message": false,
         "start_message": false,
-        "end_pattern": "Filename: (?:[\\w/:]+/(?<file>\\w+\\.\\w+))? Line: (?<line>-?\\d+)",
+        "end_pattern": "Filename: (?:[\\w/:\\.]+/(?<file>\\w+\\.\\w+))? Line: (?<line>-?\\d+)",
         "end_message": "[LOG] %{file}(line %{line}): %{message}",
         "type": "error"
       },
@@ -120,7 +121,7 @@
         "fetched_line_pattern": "(?<message>.*)\\n",
         "fetched_line_message": false,
         "start_message": false,
-        "end_pattern": "Filename: (?:[\\w/:]+/(?<file>\\w+\\.\\w+))? Line: (?<line>-?\\d+)",
+        "end_pattern": "Filename: (?:[\\w/:\\.]+/(?<file>\\w+\\.\\w+))? Line: (?<line>-?\\d+)",
         "end_message": "[LOG] %{file}(line %{line}): %{message}",
         "type": "error"
       },


### PR DESCRIPTION
<!--
Thank you for contributing to u3d!
Before you post your pull request, please make sure that you checked the boxes! (put an x in the [ ] without spaces)
If possible, try to name your pull request by prefixing it with <SUBJECT>. For instance, if you're modifying the downloading, you could prefix it with u3d/download:
-->

### Pull Request Checklist

- [x] My pull request has been rebased on master
- [x] I ran `bundle exec rspec` to make sure that my PR didn't break any test
- [x] I ran `bundle exec rubocop` to make sure that my PR is inline with our code style
- [x] I have read the [code of conduct](https://github.com/DragonBox/u3d/blob/master/CODE_OF_CONDUCT.md)

### Pull Request Description

This fixes a prettifier bug where it failed to detect the end of some specific log rules, resulting in a number of `[INIT] Could not finish active rule 'log_warning'. Aborting it. Context:`. This was due to the presence of `.` in some file names that was not properly parsed.

This also takes care of the other special characters common in file names.