### PR TITLE
u3d/* allow to modify Net::HTTP read timeout (all rubies) and max retries (ruby 2.5+) default values. Change read time out to 300 sec (fixes #258)

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,3 +191,11 @@ Your version of OpenSSL may be be outdated, make sure you are using the last one
  * __On Windows:__
 
 A fix to the issue stated above has been found on [StackOverflow](http://stackoverflow.com/questions/5720484/how-to-solve-certificate-verify-failed-on-windows). If you follow the steps described in this topic, you will most likely get rid of this issue.
+
+### Solve Connection failures
+
+If your network is flaky you might try to change the way u3d uses ruby's Net::HTTP trsnsport mechanism
+
+* set U3D_HTTP_READ_TIMEOUT (defaults 300 seconds) to change the http read timeout
+
+* U3D_HTTP_MAX_RETRIES (ruby 2.5 only, defaults 1). Ruby automatically retries once upon failures on idempotents methods. From ruby 2.5. you can change the number of time ruby might retry.


### PR DESCRIPTION
<!--
Thank you for contributing to u3d!
Before you post your pull request, please make sure that you checked the boxes! (put an x in the [ ] without spaces)
If possible, try to name your pull request by prefixing it with <SUBJECT>. For instance, if you're modifying the downloading, you could prefix it with u3d/download:
-->

### Pull Request Checklist

- [x] My pull request has been rebased on master
- [x] I ran `bundle exec rspec` to make sure that my PR didn't break any test
- [x] I ran `bundle exec rubocop` to make sure that my PR is inline with our code style
- [x] I have read the [code of conduct](https://github.com/DragonBox/u3d/blob/master/CODE_OF_CONDUCT.md)

### Pull Request Description

<!-- If this pull request is related to a specific issue, please specify here "Fixes #ISSUE_NO" -->
<!-- Please describe your pull request with as much precision as possible. Write here why you think this change is required, what problem it solves, how it solves it...  -->
<!-- Please describe to what extent you tested your modifications -->

[DESCRIBE YOUR PULL REQUEST HERE]