### PR TITLE
u3d: standardize log and descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Build Status](https://img.shields.io/circleci/project/DragonBox/u3d/master.svg?style=flat)](https://circleci.com/gh/DragonBox/u3d)
 [![Coverage Status](https://coveralls.io/repos/github/DragonBox/u3d/badge.svg?branch=master)](https://coveralls.io/github/DragonBox/u3d?branch=master)
 
-U3d is a set of tools to interact with Unity3D from command line. It is available on Linux, Macintosh and Windows.
+U3d is a set of tools to interact with Unity from command line. It is available on Linux, Macintosh and Windows.
 
 ---
 
@@ -17,38 +17,39 @@ U3d knows about your Unity project and behaves differently if invoked from withi
 
 Available commands are:
 
-* `u3d available`: List download-ready versions of Unity3d
+* `u3d available`: List download-ready versions of Unity
 
 ![u3d available](https://github.com/DragonBox/u3d/raw/master/docs/assets/u3d_available.png)
 
-* `u3d install`: Download and/or install Unity3D packages
+* `u3d install`: Download (and/or) install Unity editor packages
 
 ![u3d install](https://github.com/DragonBox/u3d/raw/master/docs/assets/u3d_install.png)
 
-* `u3d uninstall`: Uninstall Unity3D versions
+* `u3d uninstall`: Uninstall Unity versions
 
 ![u3d uninstall](https://github.com/DragonBox/u3d/raw/master/docs/assets/u3d_uninstall.png)
 
-* `u3d list`: List installed versions of Unity3d
+* `u3d list`: List installed versions of Unity
 
 ![u3d list](https://github.com/DragonBox/u3d/raw/master/docs/assets/u3d_list.png)
 
-* `u3d run`: Run Unity, and parses its output through u3d's log prettifier.
+* `u3d run`: Run Unity, and parses its output through u3d's log prettifier
 
 Here we start with the proper version of Unity:
 
 ![u3d run without arguments](https://github.com/DragonBox/u3d/raw/master/docs/assets/u3d_run_current.png)
 
 Here we pass some arguments:
+
 ![u3d run with arguments](https://github.com/DragonBox/u3d/raw/master/docs/assets/u3d_run.png)
 
-The prettifyer is on by default but can be turned off to get Unity3d's raw output.
+The prettifyer is on by default but can be turned off to get Unity's raw output.
 
 * `u3d prettify`: Prettify a saved editor logfile
 
   [Information on how `prettify` works](https://github.com/DragonBox/u3d/blob/master/LOG_RULES.md)
 
-* `u3d dependencies`: [Linux] Install dependencies that Unity don't install by default on Linux.
+* `u3d dependencies`: [Linux] Install dependencies that Unity don't install by default on Linux
 
 ## Installation
 
@@ -58,8 +59,8 @@ gem install u3d
 
 ## Unity versions numbering
 
-Unity3d uses the following version formatting: 0.0.0x0. The \'x\' can takes different values:
-  * 'f' are the main release candidates for Unity3d
+Unity uses the following version formatting: 0.0.0x0. The \'x\' can takes different values:
+  * 'f' are the main release candidates for Unity
   * 'p' are patches fixing those releases
   * 'b' are the beta releases
   * 'a' are the alpha releases (not currently discovered online)
@@ -86,7 +87,7 @@ When referencing to a version on the CLI, u3d sanitizes these weird versions. Fo
 
   u3d should be able to find the different unity installed under those locations. If the Unity installations are not in those locations, u3d might not find them automatically.
 
-## Sanitize / standardize Unity3d installation paths
+## Sanitize / standardize Unity installation paths
 
   If you have installed Unity in different locations, u3d might discover them and propose you to move them to its standard location. The procedure should be self described and easily revertible (manually). This sanitization operation is only proposed in interactive mode (i.e. if you are not using u3d unattended, e.g. in a build script on a CI server).
 
@@ -136,7 +137,7 @@ u3d install 5.6.0f3 --no-download
 u3d run -- -batchmode -quit -logFile `pwd`/editor.log -executeMethod "WWTK.SimpleBuild.PerformAndroidBuild"
 ```
 
-* Open the proper Unity3d for the current project, displaying the raw editor logs in the command line:
+* Open the proper Unity for the current project, displaying the raw editor logs in the command line:
 
 ```shell
 u3d run -r

--- a/fastlane-plugin-u3d/README.md
+++ b/fastlane-plugin-u3d/README.md
@@ -12,7 +12,7 @@ fastlane add_plugin u3d
 
 ## About u3d
 
-Fastgame's u3d (a Unity3d CLI) integration
+Fastgame's u3d (a Unity CLI) integration
 
 **Note to author:** Add a more detailed description about this plugin here. If your plugin contains multiple actions, make sure to mention them here.
 

--- a/fastlane-plugin-u3d/fastlane-plugin-u3d.gemspec
+++ b/fastlane-plugin-u3d/fastlane-plugin-u3d.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.author        = %q{Jerome Lacoste}
   spec.email         = %q{jerome.lacoste@gmail.com}
 
-  spec.summary       = %q{Fastgame's u3d (a Unity3d CLI) integration}
+  spec.summary       = %q{Fastgame's u3d (a Unity CLI) integration}
   spec.homepage      = "https://github.com/DragonBox/u3d/tree/master/fastlane-plugin-u3d"
   spec.license       = "MIT"
 

--- a/fastlane-plugin-u3d/lib/fastlane/plugin/u3d/actions/u3d_action.rb
+++ b/fastlane-plugin-u3d/lib/fastlane/plugin/u3d/actions/u3d_action.rb
@@ -36,7 +36,7 @@ module Fastlane
       end
 
       def self.description
-        "Fastgame's u3d (a Unity3d CLI) integration"
+        "Fastgame's u3d (a Unity CLI) integration"
       end
 
       def self.authors

--- a/lib/u3d/commands_generator.rb
+++ b/lib/u3d/commands_generator.rb
@@ -71,7 +71,7 @@ module U3d
         run_args = extract_run_args
 
         c.syntax = 'u3d run [-u | --unity_version <version>] [-r | --raw_logs] [ -- <run_args>]'
-        c.summary = 'Run unity, and parses its output through u3d\'s log prettifier'
+        c.summary = 'Run Unity, and parse its output through u3d\'s log prettifier'
         c.description =  %(
 #{c.summary}
 The default prettifier rules file is packaged with u3d (#{U3d::LogAnalyzer::RULES_PATH}).
@@ -93,8 +93,8 @@ Fore more information about how the rules work, see https://github.com/DragonBox
       command :list do |c|
         c.syntax = 'u3d list [-p | --packages]'
         c.option '-p', '--packages', 'Lists installed packages as well'
-        c.example 'List currently installed Unity3d versions, as well as installed packages', 'u3d list -p'
-        c.description = 'List installed versions of Unity3d'
+        c.example 'List currently installed Unity versions, as well as installed packages', 'u3d list -p'
+        c.summary = 'List installed versions of Unity'
         c.action do |_args, options|
           Commands.list_installed(options: convert_options(options))
         end
@@ -114,7 +114,7 @@ Fore more information about how the rules work, see https://github.com/DragonBox
         c.example 'List all versions available for Linux platform', 'u3d available -o linux'
         c.example 'List packages available for Unity version 5.6.0f3', 'u3d available -u 5.6.0f3 -p'
         c.example 'List packages available for Unity version containing the 5.6 string', 'u3d available -u \'5.6\' -p'
-        c.description = 'List download-ready versions of Unity3d'
+        c.summary = 'List download-ready versions of Unity'
         c.action do |_args, options|
           options.default packages: false
           Commands.list_available(options: convert_options(options))
@@ -124,7 +124,7 @@ Fore more information about how the rules work, see https://github.com/DragonBox
       command :install do |c|
         oses = U3dCore::Helper.operating_systems
         c.syntax = 'u3d install [<version>] [ [-p | --packages <package1>,<package2> ...] | [-o | --operating_system <OS>] [-a | --all] ] [--[no-]download] [ [--[no-]install] [-i | --installation_path <path>] ]'
-        c.summary = "Download (and/or) install Unity3D editor packages."
+        c.summary = 'Download (and/or) install Unity editor packages'
         c.description = %(
 #{c.summary}
 This command allows you to either:
@@ -159,7 +159,7 @@ E.g. U3D_DOWNLOAD_PATH=/some/path/you/want u3d install ...
 
       command :uninstall do |c|
         c.syntax = 'u3d uninstall [<version>]'
-        c.description = "Uninstall the specified Unity3d version."
+        c.summary = 'Uninstall the specified Unity version'
         c.option '-k', '--keychain', 'Gain privileges right through the keychain. [OSX only]'
         c.example 'Uninstall Unity version 5.2.1f1', 'u3d uninstall 5.1.2f1'
         c.action do |args, options|
@@ -169,7 +169,7 @@ E.g. U3D_DOWNLOAD_PATH=/some/path/you/want u3d install ...
 
       command :dependencies do |c|
         c.syntax = 'u3d dependencies'
-        c.summary = 'Installs Unity dependencies. [Linux only]'
+        c.summary = 'Install Unity dependencies [Linux only]'
         c.description = %(
 #{c.summary}
 Regarding the package manager: if dpkg is installed, u3d uses apt-get else if rpm is installed yum is used. If none of them is insalled, fails.
@@ -183,7 +183,7 @@ More on that: https://forum.unity3d.com/threads/unity-on-linux-release-notes-and
 
       command :credentials do |c|
         c.syntax = "u3d credentials <#{Commands.credentials_actions.join(' | ')}>"
-        c.description = 'Manages keychain credentials so u3d remembers them. [OSX only]'
+        c.summary = 'Manage keychain credentials so u3d remembers them [OSX only]'
         c.action do |args, _options|
           Commands.credentials(args: args)
         end
@@ -191,7 +191,7 @@ More on that: https://forum.unity3d.com/threads/unity-on-linux-release-notes-and
 
       command :prettify do |c|
         c.syntax = 'u3d prettify <logfile>'
-        c.summary = 'Prettify a saved logfile'
+        c.summary = 'Prettify a saved Unity logfile'
         c.description = %(
           #{c.summary}
           The default prettifier rules file is packaged with u3d (#{U3d::LogAnalyzer::RULES_PATH}).

--- a/lib/u3d/installer.rb
+++ b/lib/u3d/installer.rb
@@ -52,7 +52,7 @@ module U3d
       unclean = []
       installer.installed.each { |unity| unclean << unity unless unity.clean_install? }
       return if unclean.empty?
-      UI.important("u3d can optionally standardize the existing Unity3d installation names and locations.")
+      UI.important("u3d can optionally standardize the existing Unity installation names and locations.")
       UI.important("Check the documentation for more information:")
       UI.important("** https://github.com/DragonBox/u3d/blob/master/README.md#default-installation-paths **")
       unclean.each { |unity| installer.sanitize_install(unity, dry_run: true) }

--- a/lib/u3d/version.rb
+++ b/lib/u3d/version.rb
@@ -22,7 +22,7 @@
 
 module U3d
   VERSION = '1.0.19'.freeze
-  DESCRIPTION = 'Provides numerous tools for installing, managing and running the Unity3D game engine from command line.'.freeze
+  DESCRIPTION = 'Provides numerous tools for installing, managing and running the Unity game engine from command line.'.freeze
   UNITY_VERSIONS_NOTE = "Unity uses the following version formatting: 0.0.0x0. The \'x\' can takes different values:\n"\
   "\t. 'f' are the main release candidates for Unity\n"\
   "\t. 'p' are patches fixing those releases\n"\

--- a/lib/u3d/version.rb
+++ b/lib/u3d/version.rb
@@ -23,8 +23,8 @@
 module U3d
   VERSION = '1.0.19'.freeze
   DESCRIPTION = 'Provides numerous tools for installing, managing and running the Unity3D game engine from command line.'.freeze
-  UNITY_VERSIONS_NOTE = "Unity3d uses the following version formatting: 0.0.0x0. The \'x\' can takes different values:\n"\
-  "\t. 'f' are the main release candidates for Unity3d\n"\
+  UNITY_VERSIONS_NOTE = "Unity uses the following version formatting: 0.0.0x0. The \'x\' can takes different values:\n"\
+  "\t. 'f' are the main release candidates for Unity\n"\
   "\t. 'p' are patches fixing those releases\n"\
   "\t. 'b' are the beta releases\n"\
   "\t. 'a' are the alpha releases (not currently discovered)\n".freeze


### PR DESCRIPTION
### Pull Request Checklist

- [x] My pull request has been rebased on master
- [x] I ran `bundle exec rspec` to make sure that my PR didn't break any test
- [x] I ran `bundle exec rubocop` to make sure that my PR is inline with our code style
- [x] I have read the [code of conduct](https://github.com/DragonBox/u3d/blob/master/CODE_OF_CONDUCT.md)

### Pull Request Description

This standardizes the various output of u3d. Unity is at times referenced as Unity3d or Unity3D. The commands are also quite chaotic, and very different in the way they were described. This pull request aims to bring a bit more harmony in the various outputs of u3d so that the tool is less confusing and easier to use.