### PR TITLE
Move duplicated data_path out of U3d::Cache/U3d::INIparser to U3dCore::Helper

### DIFF
--- a/lib/u3d/cache.rb
+++ b/lib/u3d/cache.rb
@@ -31,11 +31,7 @@ module U3d
   class Cache
     using ::CoreExtensions::OperatingSystem
 
-    # Path to the directory containing the cache for the different OS
-    DEFAULT_LINUX_PATH = File.join(ENV['HOME'], '.u3d').freeze
-    DEFAULT_MAC_PATH = File.join(ENV['HOME'], 'Library', 'Application Support', 'u3d').freeze
-    DEFAULT_WINDOWS_PATH = File.join(ENV['HOME'], 'AppData', 'Local', 'u3d').freeze
-    # Name of the file itself
+    # Name of the cache file
     DEFAULT_NAME = 'cache.json'.freeze
     # Maximum duration after which the cache is considered outdated
     # Currently set to 24h
@@ -73,14 +69,7 @@ module U3d
     end
 
     def self.default_os_path
-      case U3dCore::Helper.operating_system
-      when :linux
-        DEFAULT_LINUX_PATH
-      when :mac
-        DEFAULT_MAC_PATH
-      when :win
-        DEFAULT_WINDOWS_PATH
-      end
+      U3dCore::Helper.data_path
     end
 
     private #-------------------------------------------------------------------

--- a/lib/u3d/iniparser.rb
+++ b/lib/u3d/iniparser.rb
@@ -31,9 +31,6 @@ module U3d
     # @!group INI parameters to load and save ini files
     #####################################################
     INI_NAME = 'unity-%<version>s-%<os>s.ini'.freeze
-    INI_LINUX_PATH = File.join(ENV['HOME'], '.u3d', 'ini_files').freeze
-    INI_MAC_PATH = File.join(ENV['HOME'], 'Library', 'Application Support', 'u3d', 'ini_files').freeze
-    INI_WIN_PATH = File.join(ENV['HOME'], 'AppData', 'Local', 'u3d', 'ini_files').freeze
 
     class << self
       def load_ini(version, cached_versions, os: U3dCore::Helper.operating_system, offline: false)
@@ -106,14 +103,7 @@ url=#{url}
       end
 
       def default_ini_path
-        case U3dCore::Helper.operating_system
-        when :linux
-          INI_LINUX_PATH
-        when :mac
-          INI_MAC_PATH
-        when :win
-          INI_WIN_PATH
-        end
+        File.join(U3dCore::Helper.data_path, 'ini_files')
       end
     end
   end

--- a/lib/u3d_core/helper.rb
+++ b/lib/u3d_core/helper.rb
@@ -26,6 +26,21 @@ require 'colored'
 
 module U3dCore
   module Helper
+    DEFAULT_LINUX_PATH = File.join(ENV['HOME'], '.u3d').freeze
+    DEFAULT_MAC_PATH = File.join(ENV['HOME'], 'Library', 'Application Support', 'u3d').freeze
+    DEFAULT_WINDOWS_PATH = File.join(ENV['HOME'], 'AppData', 'Local', 'u3d').freeze
+
+    def self.data_path
+      case operating_system
+      when :linux
+        DEFAULT_LINUX_PATH
+      when :mac
+        DEFAULT_MAC_PATH
+      when :win
+        DEFAULT_WINDOWS_PATH
+      end
+    end
+
     # Runs a given command using backticks (`)
     # and prints them out using the UI.command method
     def self.backticks(command, print: true)


### PR DESCRIPTION
### Pull Request Checklist

- [x] My pull request has been rebased on master
- [x] I ran `bundle exec rspec` to make sure that my PR didn't break any test
- [x] I ran `bundle exec rubocop` to make sure that my PR is inline with our code style
- [x] I have read the [code of conduct](https://github.com/DragonBox/u3d/blob/master/CODE_OF_CONDUCT.md)

### Pull Request Description

Move the duplicated data_path into a helper method so that it is only defined once, and can be used elsewhere.