### PR TITLE
u3d/prettify: Fix UnityEngine.Debug.LogXXXFormat not being caught

### DIFF
--- a/config/log_rules.json
+++ b/config/log_rules.json
@@ -53,7 +53,7 @@
       },
       "log": {
         "active": true,
-        "start_pattern": "UnityEngine\\.Debug:Log\\(Object\\)",
+        "start_pattern": "UnityEngine\\.Debug:Log(?:Format)?\\((?:String, )?Object(?:\\[\\])?\\)",
         "fetch_first_line_not_matching": [
           "UnityEngine\\.",
           "^\\n"
@@ -66,7 +66,7 @@
       },
       "log_assertion": {
         "active": true,
-        "start_pattern": "UnityEngine\\.Debug:LogAssertion\\(Object\\)",
+        "start_pattern": "UnityEngine\\.Debug:LogAssertion(?:Format)?\\((?:String, )?Object(?:\\[\\])?\\)",
         "fetch_first_line_not_matching": [
           "UnityEngine\\.",
           "^\\n"
@@ -80,7 +80,7 @@
       },
       "log_warning": {
         "active": true,
-        "start_pattern": "UnityEngine\\.Debug:LogWarning\\(Object\\)",
+        "start_pattern": "UnityEngine\\.Debug:LogWarning(?:Format)?\\((?:String, )?Object(?:\\[\\])?\\)",
         "fetch_first_line_not_matching": [
           "UnityEngine\\.",
           "^\\n",
@@ -95,7 +95,7 @@
       },
       "log_error": {
         "active": true,
-        "start_pattern": "UnityEngine\\.Debug:LogError\\(Object\\)",
+        "start_pattern": "UnityEngine\\.Debug:LogError(?:Format)?\\((?:String, )?Object(?:\\[\\])?\\)",
         "fetch_first_line_not_matching": [
           "UnityEngine\\.",
           "^\\n",


### PR DESCRIPTION
### Pull Request Checklist

- [x] My pull request has been rebased on master
- [x] I ran `bundle exec rspec` to make sure that my PR didn't break any test
- [x] I ran `bundle exec rubocop` to make sure that my PR is inline with our code style
- [x] I have read the [code of conduct](https://github.com/DragonBox/u3d/blob/master/CODE_OF_CONDUCT.md)

### Pull Request Description

Fixes #269 

This simply makes it so that the prettifier rules for logging (normal, assertion, warning and error) match format logs as well so that they appear in the prettifier output (and consequently in the `u3d run` output as well). I have extended the pattern for matching a logging rule so that `Debug.LogXXXFormat` is treated the same way as `Debug.LogXXX`, making it easier to read logs.