### PR TITLE
u3d/prettify: Catch Enlighten jobs failure

### DIFF
--- a/config/log_rules.json
+++ b/config/log_rules.json
@@ -297,6 +297,14 @@
     "comment": "Asset managing and packaging",
     "phase_start_pattern": "Packing sprites",
     "rules": {
+      "enlighten_failure": {
+        "active": true,
+        "start_pattern": "'(?<jobname>.+)' job failed with error code: (?<code>-?\\d+) \\('(?<message>.+)'\\)",
+        "start_message": false,
+        "end_pattern": "Filename: (?:.+/(?<file>\\w+\\.\\w+\\.\\w+))? Line: (?<line>-?\\d+)",
+        "end_message": "Enlighten job \"%{jobname}\" failed with status code %{code} %{file}(line %{line}): %{message}",
+        "type": "error"
+      },
       "pack_warning": {
         "active": true,
         "start_pattern": "WARNING: (?<message>.+)",


### PR DESCRIPTION
### Pull Request Checklist

- [x] My pull request has been rebased on master
- [x] I ran `bundle exec rspec` to make sure that my PR didn't break any test
- [x] I ran `bundle exec rubocop` to make sure that my PR is inline with our code style
- [x] I have read the [code of conduct](https://github.com/DragonBox/u3d/blob/master/CODE_OF_CONDUCT.md)

### Pull Request Description

The u3d prettifier currently fails to catch most enlighten messages. While these are not the most important messages, failure must be caught as they cause builds to fail. This PR addresses that issue.