### PR TITLE
u3d/prettify: fix exception rule start pattern

### DIFF
--- a/config/log_rules.json
+++ b/config/log_rules.json
@@ -24,7 +24,7 @@
       },
       "exception": {
         "active": true,
-        "start_pattern": "[eE]xception\\w*: (?<message>.*)\\n",
+        "start_pattern": "^(?:(?!\\().)*[eE]xception\\w*: (?<message>.*)\\n",
         "end_pattern": "(?:Filename: (?:[\\w/:]+/(?<file>\\w+\\.\\w+))? Line: (?<line>-?\\d+)|(?<fileunknown>filename unknown)>:(?<lineunknown>-?\\d+))",
         "start_message": false,
         "end_message": "%{file}%{fileunknown}(line %{line}%{lineunknown}): %{message}",


### PR DESCRIPTION
### Pull Request Checklist

- [x] My pull request has been rebased on master
- [x] I ran `bundle exec rspec` to make sure that my PR didn't break any test
- [x] I ran `bundle exec rubocop` to make sure that my PR is inline with our code style
- [x] I have read the [code of conduct](https://github.com/DragonBox/u3d/blob/master/CODE_OF_CONDUCT.md)

### Pull Request Description

The prettifier was considering that lines such as the following

```
This is a warning because of an exception (Exception: message)
```

should start the exception rule, while it should not. This makes it so
that the rule makes sure that there is no parenthesis on the line before
the exception to start the exception rule.
