### PR TITLE
u3d/prettify: catch build pipeline messages

### DIFF
--- a/config/log_rules.json
+++ b/config/log_rules.json
@@ -125,6 +125,22 @@
         "end_message": "[LOG] %{file}(line %{line}): %{message}",
         "type": "error"
       },
+      "build_pipeline_message": {
+        "active": true,
+        "start_pattern": "UnityEditor\\.BuildPipeline:BuildPlayerInternalNoCheck",
+        "fetch_first_line_not_matching": [
+          "UnityEditor\\.",
+          "^\\n",
+          "^\\t",
+          "^  "
+        ],
+        "fetched_line_pattern": "(?<message>.*)\\n",
+        "fetched_line_message": false,
+        "start_message": false,
+        "end_pattern": "Filename: (?:.+/(?<file>\\w+\\.\\w+\\.\\w+))? Line: (?<line>-?\\d+)",
+        "end_message": "[LOG] %{file}(line %{line}): %{message}",
+        "type": "warning"
+      },
       "batchmode_exit": {
         "active": true,
         "start_pattern": "Exiting batchmode successfully now!",


### PR DESCRIPTION
### Pull Request Checklist

- [x] My pull request has been rebased on master
- [x] I ran `bundle exec rspec` to make sure that my PR didn't break any test
- [x] I ran `bundle exec rubocop` to make sure that my PR is inline with our code style
- [x] I have read the [code of conduct](https://github.com/DragonBox/u3d/blob/master/CODE_OF_CONDUCT.md)

### Pull Request Description

Addresses #278 

The u3d prettifier failed to catch the messages displayed by the buildpipeline, thus missing on critical information. The messages are displayed as warnings, as most messages coming from the build pipeline are.