### PR TITLE
u3d/sanitize: sanitize on list only + cleanups and refactors

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Right now u3d has light support for build numbers. The build number can be found
 
 ## Sanitize / standardize Unity installation paths
 
-  If you have installed Unity in different locations, u3d might discover them and propose you to move them to its standard location. The procedure should be self described and easily revertible (manually). This sanitization operation is only proposed in interactive mode (i.e. if you are not using u3d unattended, e.g. in a build script on a CI server).
+  If you have installed Unity in different locations, u3d might discover them and propose you to move them to its standard location. The procedure should be self described and easily revertible (manually). This sanitization operation is only proposed in interactive mode (i.e. if you are not using u3d unattended, e.g. in a build script on a CI server) when running the `list` command.
 
 ![u3d sanitize](https://github.com/DragonBox/u3d/raw/master/docs/assets/u3d_sanitize.png)
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Unity uses the following version formatting: 0.0.0x0. The \'x\' can takes differ
 
 Some versions are known to have a different numbering, e.g. Linux 2017.1.0f3 is named 2017.1.0xf3Linux. Its `ProjectSettings/ProjectVersion.txt` will contain the Linux specific version.
 
-When referencing to a version on the CLI, u3d sanitizes these weird versions. For example, if you ask u3d to launch unity 2017.1.0f3 on Linux, you can use `u3d -u 2017.1.0f3` and it will find "2017.1.0xf3Linux".
+When referencing to a version on the CLI, u3d normalizes these weird versions. For example, if you ask u3d to launch unity 2017.1.0f3 on Linux, you can use `u3d -u 2017.1.0f3` and it will find "2017.1.0xf3Linux".
 
 ### Unity build numbers
 

--- a/lib/u3d/commands.rb
+++ b/lib/u3d/commands.rb
@@ -245,15 +245,7 @@ module U3d
       def installed_sanitized_sorted_versions
         installer = Installer.create
         installer.sanitize_installs
-        list = installer.installed
-        return [] if list.empty?
-        # version -> installations
-        arraym = list.map { |a| [a.version, a] }
-        map = Hash[*arraym.flatten]
-        # sorted versions
-        vcomparators = map.keys.map { |k| UnityVersionComparator.new(k) }
-        sorted_keys = vcomparators.sort.map { |v| v.version.to_s }
-        sorted_keys.map { |k| map[k] }
+        installer.installed_sorted_by_versions
       end
 
       def cache_versions(os, offline: false, force_refresh: false)

--- a/lib/u3d/commands.rb
+++ b/lib/u3d/commands.rb
@@ -43,18 +43,12 @@ module U3d
 
     class << self
       def list_installed(options: {})
-        list = Installer.create.installed
+        list = installed_sorted_versions
         if list.empty?
           UI.important 'No Unity version installed'
           return
         end
-        # version -> installations
-        arraym = list.map { |a| [a.version, a] }
-        map = Hash[*arraym.flatten]
-        # sorted versions
-        vcomparators = map.keys.map { |k| UnityVersionComparator.new(k) }
-        sorted_keys = vcomparators.sort.map { |v| v.version.to_s }
-        sorted_keys.map { |k| map[k] }.each do |u|
+        list.each do |u|
           version_format = "Version %-15{version} [%<build_number>s]  (%<root_path>s)"
           h = { version: u.version, build_number: u.build_number, root_path: u.root_path }
           UI.message version_format % h
@@ -247,6 +241,18 @@ module U3d
       end
 
       private
+
+      def installed_sorted_versions
+        list = Installer.create.installed
+        return [] if list.empty?
+        # version -> installations
+        arraym = list.map { |a| [a.version, a] }
+        map = Hash[*arraym.flatten]
+        # sorted versions
+        vcomparators = map.keys.map { |k| UnityVersionComparator.new(k) }
+        sorted_keys = vcomparators.sort.map { |v| v.version.to_s }
+        sorted_keys.map { |k| map[k] }
+      end
 
       def cache_versions(os, offline: false, force_refresh: false)
         cache = Cache.new(force_os: os, offline: offline, force_refresh: force_refresh, central_cache: true)

--- a/lib/u3d/commands.rb
+++ b/lib/u3d/commands.rb
@@ -43,7 +43,7 @@ module U3d
 
     class << self
       def list_installed(options: {})
-        list = installed_sorted_versions
+        list = installed_sanitized_sorted_versions
         if list.empty?
           UI.important 'No Unity version installed'
           return
@@ -242,8 +242,10 @@ module U3d
 
       private
 
-      def installed_sorted_versions
-        list = Installer.create.installed
+      def installed_sanitized_sorted_versions
+        installer = Installer.create
+        installer.sanitize_installs
+        list = installer.installed
         return [] if list.empty?
         # version -> installations
         arraym = list.map { |a| [a.version, a] }

--- a/lib/u3d/commands.rb
+++ b/lib/u3d/commands.rb
@@ -43,7 +43,9 @@ module U3d
 
     class << self
       def list_installed(options: {})
-        list = installed_sanitized_sorted_versions
+        installer = Installer.create
+        installer.sanitize_installs
+        list = installer.installed_sorted_by_versions
         if list.empty?
           UI.important 'No Unity version installed'
           return
@@ -241,12 +243,6 @@ module U3d
       end
 
       private
-
-      def installed_sanitized_sorted_versions
-        installer = Installer.create
-        installer.sanitize_installs
-        installer.installed_sorted_by_versions
-      end
 
       def cache_versions(os, offline: false, force_refresh: false)
         cache = Cache.new(force_os: os, offline: offline, force_refresh: force_refresh, central_cache: true)

--- a/lib/u3d/installer.rb
+++ b/lib/u3d/installer.rb
@@ -77,6 +77,18 @@ module U3d
       return unless UI.confirm("#{unclean.count} Unity installation(s) will be moved. Proceed??")
       unclean.each { |unity| sanitize_install(unity) }
     end
+
+    def installed_sorted_by_versions
+      list = installed
+      return [] if list.empty?
+      # version -> installations
+      arraym = list.map { |a| [a.version, a] }
+      map = Hash[*arraym.flatten]
+      # sorted versions
+      vcomparators = map.keys.map { |k| UnityVersionComparator.new(k) }
+      sorted_keys = vcomparators.sort.map { |v| v.version.to_s }
+      sorted_keys.map { |k| map[k] }
+    end
   end
 
   class CommonInstaller

--- a/spec/support/setups.rb
+++ b/spec/support/setups.rb
@@ -52,13 +52,18 @@ def on_fake_os_not_linux
 end
 
 def are_installed(installations)
-  installer = double("Installer")
-  allow(U3d::Installer).to receive(:create) { installer }
-  allow(installer).to receive(:installed) { installations }
+  double_installer(installations)
 end
 
 def nothing_installed
-  are_installed []
+  double_installer
+end
+
+def double_installer(installations = [])
+  installer = double("Installer")
+  allow(U3d::Installer).to receive(:create) { installer }
+  allow(installer).to receive(:installed) { installations }
+  installer
 end
 
 def expect_privileges_check

--- a/spec/u3d/commands_spec.rb
+++ b/spec/u3d/commands_spec.rb
@@ -33,6 +33,7 @@ describe U3d do
       it 'logs a message when no version is installed' do
         installer = double_installer
         expect(installer).to receive(:sanitize_installs)
+        expect(installer).to receive(:installed_sorted_by_versions) { [] }
 
         expect(U3d::UI).to receive(:important).with(/[nN]o.*install/) {}
 
@@ -41,18 +42,21 @@ describe U3d do
 
       context 'when one or more version are installed' do
         it 'logs installed version when there is only one' do
-          installed = [fake_installation('1.2.3f4')]
-          installer = are_installed(installed)
+          sorted_installed = [fake_installation('1.2.3f4')]
+          installer = double_installer
           expect(installer).to receive(:sanitize_installs)
+          expect(installer).to receive(:installed_sorted_by_versions) { sorted_installed }
 
           expect(U3d::UI).to receive(:message).with(/1.2.3f4.*foo/)
 
-          expect(U3d::Commands.list_installed).to eq installed
+          expect(U3d::Commands.list_installed).to eq sorted_installed
         end
 
         it 'logs installed packages as well when --packages option is specified' do
-          installer = are_installed([fake_installation('1.2.3f4', packages: %w[packageA packageB])])
+          sorted_installed = [fake_installation('1.2.3f4', packages: %w[packageA packageB])]
+          installer = double_installer
           expect(installer).to receive(:sanitize_installs)
+          expect(installer).to receive(:installed_sorted_by_versions) { sorted_installed }
 
           expect(U3d::UI).to receive(:message).with(/1.2.3f4.*foo/)
           expect(U3d::UI).to receive(:message).with(/Packages/)
@@ -66,13 +70,17 @@ describe U3d do
           i1 = fake_installation('1.2.3f6')
           i2 = fake_installation('1.2.3b2')
           i3 = fake_installation('1.2.3f4')
-          installer = are_installed([i1, i2, i3])
+
+          sorted_installed = [i2, i3, i1]
+          installer = double_installer
           expect(installer).to receive(:sanitize_installs)
+          expect(installer).to receive(:installed_sorted_by_versions) { sorted_installed }
+
           expect(U3d::UI).to receive(:message).with(/1.2.3b2.*foo/).ordered
           expect(U3d::UI).to receive(:message).with(/1.2.3f4.*foo/).ordered
           expect(U3d::UI).to receive(:message).with(/1.2.3f6.*foo/).ordered
 
-          expect(U3d::Commands.list_installed).to eq [i2, i3, i1]
+          expect(U3d::Commands.list_installed).to eq sorted_installed
         end
       end
       # when we support a specific version number (e.g. to list the packages of that version)

--- a/spec/u3d/commands_spec.rb
+++ b/spec/u3d/commands_spec.rb
@@ -31,7 +31,8 @@ describe U3d do
     # ---
     describe "#list_installed" do
       it 'logs a message when no version is installed' do
-        nothing_installed
+        installer = double_installer
+        expect(installer).to receive(:sanitize_installs)
 
         expect(U3d::UI).to receive(:important).with(/[nN]o.*install/) {}
 
@@ -41,7 +42,8 @@ describe U3d do
       context 'when one or more version are installed' do
         it 'logs installed version when there is only one' do
           installed = [fake_installation('1.2.3f4')]
-          are_installed(installed)
+          installer = are_installed(installed)
+          expect(installer).to receive(:sanitize_installs)
 
           expect(U3d::UI).to receive(:message).with(/1.2.3f4.*foo/)
 
@@ -49,7 +51,8 @@ describe U3d do
         end
 
         it 'logs installed packages as well when --packages option is specified' do
-          are_installed([fake_installation('1.2.3f4', packages: %w[packageA packageB])])
+          installer = are_installed([fake_installation('1.2.3f4', packages: %w[packageA packageB])])
+          expect(installer).to receive(:sanitize_installs)
 
           expect(U3d::UI).to receive(:message).with(/1.2.3f4.*foo/)
           expect(U3d::UI).to receive(:message).with(/Packages/)
@@ -63,7 +66,8 @@ describe U3d do
           i1 = fake_installation('1.2.3f6')
           i2 = fake_installation('1.2.3b2')
           i3 = fake_installation('1.2.3f4')
-          are_installed([i1, i2, i3])
+          installer = are_installed([i1, i2, i3])
+          expect(installer).to receive(:sanitize_installs)
           expect(U3d::UI).to receive(:message).with(/1.2.3b2.*foo/).ordered
           expect(U3d::UI).to receive(:message).with(/1.2.3f4.*foo/).ordered
           expect(U3d::UI).to receive(:message).with(/1.2.3f6.*foo/).ordered

--- a/spec/u3d/installer_spec.rb
+++ b/spec/u3d/installer_spec.rb
@@ -71,6 +71,22 @@ describe U3d do
           end
         end
       end
+
+      describe ".installed_sorted_by_versions" do
+        it "sorts by version" do
+          i1 = fake_installation('1.2.3f6')
+          i2 = fake_installation('1.2.3b2')
+          i3 = fake_installation('1.2.3f4')
+
+          installed = [i1, i2, i3]
+          sorted_installed = [i2, i3, i1]
+
+          installer = DummyInstaller.new
+          allow(installer).to receive(:installed) { installed }
+
+          expect(installer.installed_sorted_by_versions).to eq(sorted_installed)
+        end
+      end
     end
 
     describe U3d::MacInstaller, unless: WINDOWS do

--- a/spec/u3d/installer_spec.rb
+++ b/spec/u3d/installer_spec.rb
@@ -25,47 +25,50 @@ require 'support/installations'
 
 describe U3d do
   describe U3d::Installer do
-    describe ".create" do
-      context "Clean installs" do
-        it "allows to list the installed versions and doesn't ask for sanitization" do
-          allow(U3d::Helper).to receive(:mac?) { false }
-          allow(U3d::Helper).to receive(:linux?) { true }
-          allow(U3dCore::UI).to receive(:confirm).with(/2 Unity .* will be moved/) { 'y' }
-
-          installed = [linux_5_6_standard]
-
-          installer = double("LinuxInstaller")
-          allow(U3d::LinuxInstaller).to receive(:new) { installer }
-          allow(installer).to receive(:installed) { installed }
-
-          expect(U3d::UI).to_not receive(:important)
-          expect(installer).to_not receive(:sanitize_install)
-
-          U3d::Installer.create
-        end
+    describe U3d::BaseInstaller do
+      class DummyInstaller < U3d::BaseInstaller
       end
+      describe ".sanitize_installs" do
+        context "Clean installs" do
+          it "allows to list the installed versions and doesn't ask for sanitization" do
+            allow(U3d::Helper).to receive(:mac?) { false }
+            allow(U3d::Helper).to receive(:linux?) { true }
+            allow(U3dCore::UI).to receive(:confirm).with(/2 Unity .* will be moved/) { 'y' }
 
-      context "Unclean installs" do
-        it "allows to list the installed versions and ask for sanitization" do
-          allow(U3d::Helper).to receive(:mac?) { true }
-          allow(U3dCore::UI).to receive(:confirm).with(/2 Unity .* will be moved/) { 'y' }
-          installed = [macinstall_5_6_custom_with_space, macinstall_5_6_default]
+            installed = [linux_5_6_standard]
 
-          installer = double("MacInstaller")
-          allow(U3d::MacInstaller).to receive(:new) { installer }
-          allow(installer).to receive(:installed) { installed }
+            installer = DummyInstaller.new
+            allow(installer).to receive(:new) { installer }
+            allow(installer).to receive(:installed) { installed }
 
-          expect(U3d::UI).to receive(:important).with(/u3d can optionally standardize/)
-          expect(U3d::UI).to receive(:important).with(/Check the documentation/)
-          expect(U3d::UI).to receive(:important).with(/github.com/)
+            expect(U3d::UI).to_not receive(:important)
+            expect(installer).to_not receive(:sanitize_install)
 
-          expect(installer).to receive(:sanitize_install).with(installed[0], dry_run: true)
-          expect(installer).to receive(:sanitize_install).with(installed[1], dry_run: true)
+            installer.sanitize_installs
+          end
+        end
 
-          expect(installer).to receive(:sanitize_install).with(installed[0])
-          expect(installer).to receive(:sanitize_install).with(installed[1])
+        context "Unclean installs" do
+          it "allows to list the installed versions and ask for sanitization" do
+            allow(U3d::Helper).to receive(:mac?) { true }
+            allow(U3dCore::UI).to receive(:confirm).with(/2 Unity .* will be moved/) { 'y' }
+            installed = [macinstall_5_6_custom_with_space, macinstall_5_6_default]
 
-          U3d::Installer.create
+            installer = DummyInstaller.new
+            allow(installer).to receive(:installed) { installed }
+
+            expect(U3d::UI).to receive(:important).with(/u3d can optionally standardize/)
+            expect(U3d::UI).to receive(:important).with(/Check the documentation/)
+            expect(U3d::UI).to receive(:important).with(/github.com/)
+
+            expect(installer).to receive(:sanitize_install).with(installed[0], dry_run: true)
+            expect(installer).to receive(:sanitize_install).with(installed[1], dry_run: true)
+
+            expect(installer).to receive(:sanitize_install).with(installed[0])
+            expect(installer).to receive(:sanitize_install).with(installed[1])
+
+            installer.sanitize_installs
+          end
         end
       end
     end


### PR DESCRIPTION
This is a breaking functional change, but I don't think we ever advertised it. I consider the fact that we were sanitizing outside of list a bug and not something to be depended upon.