### PR TITLE
u3d/internals: grant_admin wasn't using has_admin_privileges? to get the privileges on non windows platforms

### DIFF
--- a/lib/u3d_core/command_executor.rb
+++ b/lib/u3d_core/command_executor.rb
@@ -144,6 +144,7 @@ module U3dCore
         if Helper.windows?
           raise CredentialsError, "The command \'#{command}\' must be run in administrative shell" unless has_admin_privileges?
         else
+          raise CredentialsError, "The command \'#{command}\' must be run with admin privileges" unless has_admin_privileges?
           command = "sudo -k && echo #{cred.password.shellescape} | sudo -S bash -c \"#{command}\""
         end
         UI.verbose 'Admin privileges granted for command execution'


### PR DESCRIPTION
Consequence was that in case of invalid password, it was keeping the invalid password in memory and reusing it indefinitely.