### PR TITLE
u3d/versions: Accept new pattern for mac above 2018.2+

### DIFF
--- a/lib/u3d/unity_versions.rb
+++ b/lib/u3d/unity_versions.rb
@@ -228,15 +228,19 @@ module U3d
 
       def initialize(pattern:)
         @versions = {}
-        @pattern = pattern
+        @patterns = pattern.is_a?(Array) ? pattern : [pattern]
       end
 
       def fetch_some(type, url)
         UI.message "Loading Unity #{type} releases"
-        current = UnityVersions.fetch_version_paged(url, @pattern)
-        current = UnityVersions.fetch_version(url, @pattern) if current.empty?
-        UI.success "Found #{current.count} #{type} releases."
-        @versions.merge!(current)
+        total = {}
+        @patterns.each do |pattern|
+          current = UnityVersions.fetch_version_paged(url, pattern)
+          current = UnityVersions.fetch_version(url, pattern) if current.empty?
+          total.merge!(current)
+        end
+        UI.success "Found #{total.count} #{type} releases."
+        @versions.merge!(total)
       end
 
       def fetch_all_channels

--- a/lib/u3d/unity_versions.rb
+++ b/lib/u3d/unity_versions.rb
@@ -255,7 +255,7 @@ module U3d
     class MacVersions
       class << self
         def list_available
-          VersionsFetcher.new(pattern: MAC_DOWNLOAD).fetch_all_channels
+          VersionsFetcher.new(pattern: [MAC_DOWNLOAD, MAC_DOWNLOAD_2018_2]).fetch_all_channels
         end
       end
     end

--- a/lib/u3d/unity_versions.rb
+++ b/lib/u3d/unity_versions.rb
@@ -121,6 +121,7 @@ module U3d
     # Captures a version and its base url
     LINUX_DOWNLOAD = %r{'(https?://[\w/\.-]+/[0-9a-f\+]{12,13}/)(./)?UnitySetup-(\d+\.\d+\.\d+\w\d+)'}
     MAC_DOWNLOAD = %r{"(https?://[\w/\.-]+/[0-9a-f\+]{12,13}/)MacEditorInstaller/[a-zA-Z0-9/\.\+]+-(\d+\.\d+\.\d+\w\d+)\.?\w+"}
+    MAC_DOWNLOAD_2018_2 = %r{"(https?://[\w/\.-]+/[0-9a-f\+]{12,13}/)UnityDownloadAssistant-[a-zA-Z0-9/\.\+]+-(\d+\.\d+\.\d+\w\d+)\.?\w+"}
     WIN_DOWNLOAD = %r{"(https?://[\w/\.-]+/[0-9a-f\+]{12,13}/)Windows..EditorInstaller/[a-zA-Z0-9/\.\+]+-(\d+\.\d+\.\d+\w\d+)\.?\w+"}
     LINUX_DOWNLOAD_DATED = %r{"(https?://[\w/\._-]+/unity\-editor\-installer\-(\d+\.\d+\.\d+\w\d+).*\.sh)"}
     LINUX_DOWNLOAD_RECENT_PAGE = %r{"(https?://beta\.unity3d\.com/download/[a-zA-Z0-9/\.\+]+/public_download\.html)"}


### PR DESCRIPTION
### Pull Request Checklist

- [x] My pull request has been rebased on master
- [x] I ran `bundle exec rspec` to make sure that my PR didn't break any test
- [x] I ran `bundle exec rubocop` to make sure that my PR is inline with our code style
- [x] I have read the [code of conduct](https://github.com/DragonBox/u3d/blob/master/CODE_OF_CONDUCT.md)

### Pull Request Description

Fixes #321 

Unity has introduced a new pattern for downloading the Editor in the 2018.2 release, which broke our integration.
It went from `https://download.unity3d.com/download_unity/4cb482063d12/MacEditorInstaller/Unity-2018.1.7f1.pkg` [2018.1.7f1] to `https://download.unity3d.com/download_unity/787658998520/UnityDownloadAssistant-2018.2.0f2.dmg` [2018.2.0f2]. While this also means that the installer has apparently changed, they still use the old route pattern to download the editor (meaning that `https://download.unity3d.com/download_unity/787658998520/MacEditorInstaller/Unity-2018.2.0f2.pkg` is still a valid route), so this should not be an issue.