### PR TITLE
u3d/available: Add option to not use the central cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ export LANG=en_US.UTF-8
 
 You can find your shell profile at ~/.bashrc, ~/.bash_profile or ~/.zshrc depending on your system.
 
+## Central cache
+
+Because fetching all the versions online can be rather long, especially on slow connections, u3d uses a [central cache](https://dragonbox.github.io/unities/v1/versions.json) which performs the fetching automatically and makes retrieving all the versions much faster.
+
+__NOTE__: If you do not want to use the central cache for some reason, you can still perform the version fetching manually by running `u3d available --no-central` which will cache locally the versions that you retrieved so that you can use them later (in `u3d install` for example).
+
 ## Unity versions numbering
 
 Unity uses the following version formatting: 0.0.0x0. The \'x\' can takes different values:

--- a/lib/u3d/commands.rb
+++ b/lib/u3d/commands.rb
@@ -107,8 +107,9 @@ module U3d
         ver = options[:unity_version]
         os = valid_os_or_current(options[:operating_system])
         rl = options[:release_level]
+        central = options.fetch(:central, true)
 
-        cache_versions = cache_versions(os, force_refresh: options[:force], central_cache: options[:central])
+        cache_versions = cache_versions(os, force_refresh: options[:force], central_cache: central)
 
         if ver
           cache_versions = cache_versions.extract(*cache_versions.keys.select { |k| Regexp.new(ver).match(k) })

--- a/lib/u3d/commands.rb
+++ b/lib/u3d/commands.rb
@@ -107,8 +107,9 @@ module U3d
         ver = options[:unity_version]
         os = valid_os_or_current(options[:operating_system])
         rl = options[:release_level]
+        central = !options[:no_central]
 
-        cache_versions = cache_versions(os, force_refresh: options[:force])
+        cache_versions = cache_versions(os, force_refresh: options[:force], central_cache: central)
 
         if ver
           cache_versions = cache_versions.extract(*cache_versions.keys.select { |k| Regexp.new(ver).match(k) })
@@ -265,8 +266,8 @@ module U3d
 
       private
 
-      def cache_versions(os, offline: false, force_refresh: false)
-        cache = Cache.new(force_os: os, offline: offline, force_refresh: force_refresh, central_cache: true)
+      def cache_versions(os, offline: false, force_refresh: false, central_cache: true)
+        cache = Cache.new(force_os: os, offline: offline, force_refresh: force_refresh, central_cache: central_cache)
         cache_os = cache[os.id2name] || {}
         cache_versions = cache_os['versions'] || {}
         cache_versions

--- a/lib/u3d/commands.rb
+++ b/lib/u3d/commands.rb
@@ -107,9 +107,8 @@ module U3d
         ver = options[:unity_version]
         os = valid_os_or_current(options[:operating_system])
         rl = options[:release_level]
-        central = !options[:no_central]
 
-        cache_versions = cache_versions(os, force_refresh: options[:force], central_cache: central)
+        cache_versions = cache_versions(os, force_refresh: options[:force], central_cache: options[:central])
 
         if ver
           cache_versions = cache_versions.extract(*cache_versions.keys.select { |k| Regexp.new(ver).match(k) })

--- a/lib/u3d/commands_generator.rb
+++ b/lib/u3d/commands_generator.rb
@@ -119,6 +119,7 @@ Fore more information about how the rules work, see https://github.com/DragonBox
         c.option '-o', '--operating_system STRING', String, "Checks for availability on specific OS [#{oses.join(', ')}]"
         c.option '-u', '--unity_version STRING', String, 'Checks if specified version is available. Can be a regular expression'
         c.option '-p', '--packages', 'Lists available packages as well'
+        c.option '--no_central', 'Do not use the central version'
         c.example 'List all versions available, forcing a refresh of the available packages from Unity servers', 'u3d available -f'
         c.example 'List stable versions available', 'u3d available -r stable -p'
         c.example 'List all versions available for Linux platform', 'u3d available -o linux'
@@ -127,6 +128,7 @@ Fore more information about how the rules work, see https://github.com/DragonBox
         c.summary = 'List download-ready versions of Unity'
         c.action do |_args, options|
           options.default packages: false
+          options.default no_central: false
           Commands.list_available(options: convert_options(options))
         end
       end

--- a/lib/u3d/commands_generator.rb
+++ b/lib/u3d/commands_generator.rb
@@ -114,12 +114,12 @@ Fore more information about how the rules work, see https://github.com/DragonBox
         oses = U3dCore::Helper.operating_systems
         c.syntax = 'u3d available [-r | --release_level <level>] [-o | --operating_system <OS>] [-u | --unity_version <version>] [-p | --packages] [-f | --force]'
         levels = Commands.release_levels
+        c.option '--[no-]central', 'Use or not the central version cache'
         c.option '-f', '--force', 'Force refresh list of available versions'
         c.option '-r', '--release_level STRING', String, "Checks for availability on specific release level [#{levels.join(', ')}]"
         c.option '-o', '--operating_system STRING', String, "Checks for availability on specific OS [#{oses.join(', ')}]"
         c.option '-u', '--unity_version STRING', String, 'Checks if specified version is available. Can be a regular expression'
         c.option '-p', '--packages', 'Lists available packages as well'
-        c.option '--no_central', 'Do not use the central version cache'
         c.example 'List all versions available, forcing a refresh of the available packages from Unity servers', 'u3d available -f'
         c.example 'List stable versions available', 'u3d available -r stable -p'
         c.example 'List all versions available for Linux platform', 'u3d available -o linux'
@@ -128,7 +128,7 @@ Fore more information about how the rules work, see https://github.com/DragonBox
         c.summary = 'List download-ready versions of Unity'
         c.action do |_args, options|
           options.default packages: false
-          options.default no_central: false
+          options.default central: true
           Commands.list_available(options: convert_options(options))
         end
       end

--- a/lib/u3d/commands_generator.rb
+++ b/lib/u3d/commands_generator.rb
@@ -126,6 +126,11 @@ Fore more information about how the rules work, see https://github.com/DragonBox
         c.example 'List packages available for Unity version 5.6.0f3', 'u3d available -u 5.6.0f3 -p'
         c.example 'List packages available for Unity version containing the 5.6 string', 'u3d available -u \'5.6\' -p'
         c.summary = 'List download-ready versions of Unity'
+        c.description = %(
+#{c.summary}
+This command interprets the information that are available on Unity's website and forums to fetch all the version that are available for download.
+It relies on a centralized cache (https://dragonbox.github.io/unities/v1/versions.json) that performs the fetching automatically so that you don't have to do it locally. If you do not want to use this central cache and wish to perform the fetching yourself, you can use the --no-central option.
+        )
         c.action do |_args, options|
           options.default packages: false
           options.default central: true

--- a/lib/u3d/commands_generator.rb
+++ b/lib/u3d/commands_generator.rb
@@ -119,7 +119,7 @@ Fore more information about how the rules work, see https://github.com/DragonBox
         c.option '-o', '--operating_system STRING', String, "Checks for availability on specific OS [#{oses.join(', ')}]"
         c.option '-u', '--unity_version STRING', String, 'Checks if specified version is available. Can be a regular expression'
         c.option '-p', '--packages', 'Lists available packages as well'
-        c.option '--no_central', 'Do not use the central version'
+        c.option '--no_central', 'Do not use the central version cache'
         c.example 'List all versions available, forcing a refresh of the available packages from Unity servers', 'u3d available -f'
         c.example 'List stable versions available', 'u3d available -r stable -p'
         c.example 'List all versions available for Linux platform', 'u3d available -o linux'


### PR DESCRIPTION
<!--
Thank you for contributing to u3d!
Before you post your pull request, please make sure that you checked the boxes! (put an x in the [ ] without spaces)
If possible, try to name your pull request by prefixing it with <SUBJECT>. For instance, if you're modifying the downloading, you could prefix it with u3d/download:
-->

### Pull Request Checklist

- [x] My pull request has been rebased on master
- [x] I ran `bundle exec rspec` to make sure that my PR didn't break any test
- [x] I ran `bundle exec rubocop` to make sure that my PR is inline with our code style
- [x] I have read the [code of conduct](https://github.com/DragonBox/u3d/blob/master/CODE_OF_CONDUCT.md)

### Pull Request Description

This is a small change that makes it possible to still retrieve the latest unity versions when the central cache doesn't know them. It adds an option to `u3d available`.