### PR TITLE
u3d/unity_versions: fix missing latest versions

### DIFF
--- a/lib/u3d/unity_versions.rb
+++ b/lib/u3d/unity_versions.rb
@@ -276,7 +276,8 @@ module U3d
         fetch_some('lts', UNITY_LTSES)
         fetch_some('stable', UNITY_DOWNLOADS)
         fetch_some('patch', UNITY_PATCHES)
-        fetch_some('beta', UNITY_BETAS)
+        # This does not work any longer
+        # fetch_some('beta', UNITY_BETAS)
         @versions
       end
     end

--- a/lib/u3d/unity_versions.rb
+++ b/lib/u3d/unity_versions.rb
@@ -114,6 +114,8 @@ module U3d
     UNITY_BETAS = 'https://unity3d.com/unity/beta/archive'.freeze
     # URL for a specific beta, takes into parameter a version string (%s)
     UNITY_BETA_URL = 'https://unity3d.com/unity/beta/unity%<version>s'.freeze
+    # URL for latest releases listing (since Unity 2017.1.5f1), takes into parameter os (windows => win32, mac => darwin)
+    UNITY_LATEST_JSON_URL = 'https://public-cdn.cloud.unity3d.com/hub/prod/releases-%<os>s.json'.freeze
 
     #####################################################
     # @!group REGEX: expressions to interpret data
@@ -129,6 +131,8 @@ module U3d
     # Captures a beta version in html page
     UNITY_BETAVERSION_REGEX = %r{\/unity\/beta\/unity(\d+\.\d+\.\d+\w\d+)"}
     UNITY_EXTRA_DOWNLOAD_REGEX = %r{"(https?:\/\/[\w\/.-]+\.unity3d\.com\/(\w+))\/[a-zA-Z\/.-]+\/download.html"}
+    # For the latest releases fetched from json
+    UNITY_LATEST_JSON = %r{(https?://[\w/\.-]+/[0-9a-f\+]{12,13}/)}
 
     class << self
       def list_available(os: nil)
@@ -158,6 +162,16 @@ module U3d
         U3d::Utils.get_ssl(url).scan(/\?page=\d+/).map do |page|
           fetch_version("#{url}#{page}", pattern)
         end.reduce({}, :merge)
+      end
+
+      def fetch_from_json(url, pattern)
+        require 'json'
+        data = Utils.get_ssl(url)
+        JSON.parse(data).values.flatten.select do |build|
+          pattern =~ build['downloadUrl']
+        end.map do |build|
+          [build['version'], pattern.match(build['downloadUrl'])[1]]
+        end.to_h
       end
 
       def fetch_betas(url, pattern)
@@ -243,6 +257,21 @@ module U3d
         @versions.merge!(total)
       end
 
+      def fetch_json(os)
+        UI.message 'Loading Unity latest releases'
+        url = format(UNITY_LATEST_JSON_URL, os: os)
+        latest = UnityVersions.fetch_from_json(url, UNITY_LATEST_JSON)
+
+        UI.success "Found #{latest.count} latest releases."
+
+        @versions.merge!(latest) do |key, oldval, newval|
+          UI.important "Unity version #{key} already fetched, replacing #{oldval} with #{newval}" if newval != oldval
+          newval
+        end
+
+        @versions
+      end
+
       def fetch_all_channels
         fetch_some('lts', UNITY_LTSES)
         fetch_some('stable', UNITY_DOWNLOADS)
@@ -255,7 +284,9 @@ module U3d
     class MacVersions
       class << self
         def list_available
-          VersionsFetcher.new(pattern: [MAC_DOWNLOAD, MAC_DOWNLOAD_2018_2]).fetch_all_channels
+          versions_fetcher = VersionsFetcher.new(pattern: [MAC_DOWNLOAD, MAC_DOWNLOAD_2018_2])
+          versions_fetcher.fetch_all_channels
+          versions_fetcher.fetch_json('darwin')
         end
       end
     end
@@ -263,7 +294,9 @@ module U3d
     class WindowsVersions
       class << self
         def list_available
-          VersionsFetcher.new(pattern: WIN_DOWNLOAD).fetch_all_channels
+          versions_fetcher = VersionsFetcher.new(pattern: WIN_DOWNLOAD)
+          versions_fetcher.fetch_all_channels
+          versions_fetcher.fetch_json('win32')
         end
       end
     end

--- a/lib/u3d/unity_versions.rb
+++ b/lib/u3d/unity_versions.rb
@@ -167,9 +167,7 @@ module U3d
       def fetch_from_json(url, pattern)
         require 'json'
         data = Utils.get_ssl(url)
-        JSON.parse(data).values.flatten.select do |build|
-          pattern =~ build['downloadUrl']
-        end.map do |build|
+        JSON.parse(data).values.flatten.select { |b| pattern =~ b['downloadUrl'] }.map do |build|
           [build['version'], pattern.match(build['downloadUrl'])[1]]
         end.to_h
       end

--- a/spec/support/download_archives.rb
+++ b/spec/support/download_archives.rb
@@ -37,6 +37,64 @@ def macosx_archive
   )
 end
 
+def latest_windows_archive
+  %(
+{
+  "official": [
+    {
+      "version": "2017.1.5f1",
+      "lts": false,
+      "downloadUrl": "https://download.unity3d.com/download_unity/9758a36cfaa6/Windows64EditorInstaller/UnitySetup64-2017.1.5f1.exe",
+      "downloadSize": 534723584,
+      "installedSize": 1779680256,
+      "checksum": "8937731134e0109620af32f6f52ce1c6",
+      "modules": []
+    }
+  ],
+  "beta": [
+    {
+      "version": "2018.3.0b12",
+      "lts": false,
+      "downloadUrl": "https://beta.unity3d.com/download/77f6238a7ced/Windows64EditorInstaller/UnitySetup64-2018.3.0b12.exe",
+      "downloadSize": 583775232,
+      "installedSize": 2028078080,
+      "checksum": "4238474477c552cce34072c8061c5dcd",
+      "modules": []
+    }
+  ]
+}
+  )
+end
+
+def latest_macosx_archive
+  %(
+{
+  "official": [
+    {
+      "version": "2017.1.5f1",
+      "lts": false,
+      "downloadUrl": "https://download.unity3d.com/download_unity/9758a36cfaa6/MacEditorInstaller/Unity-2017.1.5f1.pkg",
+      "downloadSize": 886532131,
+      "installedSize": 2365775000,
+      "checksum": "1de0b7d9f705dbd0eab65cbf2cc693ee",
+      "modules": []
+    }
+  ],
+  "beta": [
+    {
+      "version": "2018.3.0b12",
+      "lts": false,
+      "downloadUrl": "https://beta.unity3d.com/download/77f6238a7ced/MacEditorInstaller/Unity-2018.3.0b12.pkg",
+      "downloadSize": 1059403789,
+      "installedSize": 2683800000,
+      "checksum": "5a171c942fdcba9a6eb45d8ad1400778",
+      "modules": []
+    }
+  ]
+}
+  )
+end
+
 def linux_archive_old
   %(
     <b>5.4.0b10</b>: <a href="http://download.unity3d.com/download_unity/linux/unity-editor-installer-1.2.3f1+20160316.sh" target="_blank" class="externalLink">http://download.unity3d.com/download_unity/linux/unity-editor-installer-1.2.3f1+20160316.sh</a><br />

--- a/spec/u3d/unity_versions_spec.rb
+++ b/spec/u3d/unity_versions_spec.rb
@@ -44,18 +44,46 @@ describe U3d do
       end
     end
 
+    describe '.fetch_version' do
+      it 'reads versions for windows' do
+        expect(U3d::Utils).to receive(:get_ssl) { windows_archive }
+        expect(U3d::UnityVersions.fetch_version("foo", U3d::UnityVersions::WIN_DOWNLOAD).count).to eql 3
+      end
+
+      it 'reads versions for mac' do
+        expect(U3d::Utils).to receive(:get_ssl) { macosx_archive }
+        expect(U3d::UnityVersions.fetch_version("foo", U3d::UnityVersions::MAC_DOWNLOAD).count).to eql 3
+      end
+    end
+
+    # TODO: test U3d::UnityVersions.fetch_version_paged
+    xdescribe '.fetch_version_paged' do
+    end
+
+    describe '.fetch_from_json' do
+      it 'reads versions for windows' do
+        expect(U3d::Utils).to receive(:get_ssl) { latest_windows_archive }
+        expect(U3d::UnityVersions.fetch_from_json("foo", U3d::UnityVersions::UNITY_LATEST_JSON).count).to eql 2
+      end
+
+      it 'reads versions for mac' do
+        expect(U3d::Utils).to receive(:get_ssl) { latest_macosx_archive }
+        expect(U3d::UnityVersions.fetch_from_json("foo", U3d::UnityVersions::UNITY_LATEST_JSON).count).to eql 2
+      end
+    end
+
     describe '.list_available' do
       it 'retrieves windows versions' do
-        expect(U3d::Utils).to receive(:get_ssl) { "" } # lts
-        expect(U3d::Utils).to receive(:get_ssl) { windows_archive }
-        expect(U3d::Utils).to receive(:get_ssl).at_least(2).times { "" }
-        expect(U3d::UnityVersions.list_available(os: :win).count).to eql 3
+        expect(U3d::UnityVersions).to receive(:fetch_version_paged).at_least(3).times { {} }
+        expect(U3d::UnityVersions).to receive(:fetch_version).at_least(3).times { {} }
+        expect(U3d::UnityVersions).to receive(:fetch_from_json).at_least(:once) { {} }
+        expect(U3d::UnityVersions.list_available(os: :win).count).to eql 0
       end
       it 'retrieves mac versions' do
-        expect(U3d::Utils).to receive(:get_ssl) { "" } # lts
-        expect(U3d::Utils).to receive(:get_ssl) { macosx_archive }
-        expect(U3d::Utils).to receive(:get_ssl).at_least(2).times { "" }
-        expect(U3d::UnityVersions.list_available(os: :mac).count).to eql 3
+        expect(U3d::UnityVersions).to receive(:fetch_version_paged).at_least(6).times { {} }
+        expect(U3d::UnityVersions).to receive(:fetch_version).at_least(6).times { {} }
+        expect(U3d::UnityVersions).to receive(:fetch_from_json).at_least(:once) { {} }
+        expect(U3d::UnityVersions.list_available(os: :mac).count).to eql 0
       end
 
       context "Linux support" do


### PR DESCRIPTION
### Pull Request Checklist

- [x] My pull request has been rebased on master
- [x] I ran `bundle exec rspec` to make sure that my PR didn't break any test
- [x] I ran `bundle exec rubocop` to make sure that my PR is inline with our code style
- [x] I have read the [code of conduct](https://github.com/DragonBox/u3d/blob/master/CODE_OF_CONDUCT.md)

### Pull Request Description

Unity has recently updated their listing of the latest releases for betas notably.
This restore the functionnality by fetching the latest information.

Fixes #330  