### PR TITLE
u3d/available: Make Linux 2018.3.0f2 available on linux #337

### DIFF
--- a/lib/u3d/installation.rb
+++ b/lib/u3d/installation.rb
@@ -207,7 +207,7 @@ module U3d
 
     def strings(path)
       if `which strings` != ''
-        bintutils_strings(path)
+        binutils_strings(path)
       else
         Utils.strings(path).to_a
       end

--- a/lib/u3d/unity_versions.rb
+++ b/lib/u3d/unity_versions.rb
@@ -119,7 +119,7 @@ module U3d
     # @!group REGEX: expressions to interpret data
     #####################################################
     # Captures a version and its base url
-    LINUX_DOWNLOAD = %r{'(https?://[\w/\.-]+/[0-9a-f\+]{12,13}/)(./)?UnitySetup-(\d+\.\d+\.\d+\w\d+)'}
+    LINUX_DOWNLOAD = %r{['"](https?:\/\/[\w/\.-]+/[0-9a-f\+]{12,13}\/)(.\/)?UnitySetup-(\d+\.\d+\.\d+\w\d+)['"]}
     MAC_DOWNLOAD = %r{"(https?://[\w/\.-]+/[0-9a-f\+]{12,13}/)MacEditorInstaller/[a-zA-Z0-9/\.\+]+-(\d+\.\d+\.\d+\w\d+)\.?\w+"}
     MAC_DOWNLOAD_2018_2 = %r{"(https?://[\w/\.-]+/[0-9a-f\+]{12,13}/)UnityDownloadAssistant-(\d+\.\d+\.\d+\w\d+)\.?\w+"}
     WIN_DOWNLOAD = %r{"(https?://[\w/\.-]+/[0-9a-f\+]{12,13}/)Windows..EditorInstaller/[a-zA-Z0-9/\.\+]+-(\d+\.\d+\.\d+\w\d+)\.?\w+"}
@@ -191,13 +191,16 @@ module U3d
 
         def list_available_from_page(unity_forums, data)
           versions = {}
-          results = data.scan(LINUX_DOWNLOAD_DATED)
-          results.each do |capt|
+
+          data.scan(LINUX_DOWNLOAD_DATED) do |capt|
             versions[capt[1]] = capt[0]
           end
 
-          results = data.scan(LINUX_DOWNLOAD_RECENT_PAGE)
-          results.each do |page|
+          data.scan(LINUX_DOWNLOAD) do |capt|
+            versions[capt[2]] = capt[0]
+          end
+
+          data.scan(LINUX_DOWNLOAD_RECENT_PAGE) do |page|
             url = page[0]
             page_body = unity_forums.page_content(url)
             capt = page_body.match(LINUX_DOWNLOAD_RECENT_FILE)
@@ -218,6 +221,7 @@ module U3d
               end
             end
           end
+
           versions
         end
       end

--- a/spec/support/download_archives.rb
+++ b/spec/support/download_archives.rb
@@ -53,6 +53,7 @@ def linux_archive_all
     <b>2017.1.0b3</b>:<a href="http://beta.unity3d.com/download/b515b8958382/public_download.html" target="_blank" class="externalLink">
     <b>2017.3.0f1</b>:<a href="http://beta.unity3d.com/download/3c89f8d277f5/public_download.html" target="_blank" class="externalLink">
     <b>2017.2.1f1</b>:<a href="https://beta.unity3d.com/download/ce9f6a0436e1+/public_download.html" target="_blank" class="externalLink">
+    <b>2018.3.0f2</b>:<a href='https://beta.unity3d.com/download/6e9a27477296/UnitySetup-2018.3.0f2' target="_blank" class="externalLink">
   )
 end
 

--- a/spec/u3d/unity_versions_spec.rb
+++ b/spec/u3d/unity_versions_spec.rb
@@ -92,7 +92,7 @@ describe U3d do
           allow(U3d::INIparser).to receive(:load_ini).with('2017.3.0f1', nil, os: :linux, offline: true) {}
           allow(U3d::INIparser).to receive(:load_ini).with('2017.2.1f1', nil, os: :linux, offline: true) {}
 
-          expect(U3d::UnityVersions.list_available(os: :linux).keys).to eql ['1.2.3f1', '1.3.5f1', '2017.1.6f1', '2017.1.0b3', '2017.3.0f1', '2017.2.1f1']
+          expect(U3d::UnityVersions.list_available(os: :linux).keys).to eql ['1.2.3f1', '1.3.5f1', '2017.1.6f1', '2018.3.0f2', '2017.1.0b3', '2017.3.0f1', '2017.2.1f1']
         end
       end
     end


### PR DESCRIPTION
### Pull Request Checklist

- [x] My pull request has been rebased on master
- [x] I ran `bundle exec rspec` to make sure that my PR didn't break any test
- [x] I ran `bundle exec rubocop` to make sure that my PR is inline with our code style
- [x] I have read the [code of conduct](https://github.com/DragonBox/u3d/blob/master/CODE_OF_CONDUCT.md)

### Pull Request Description

Fixes #337, making 2018.3.0f2 available on Linux. It does this by also searching the forum pages directly for `LINUX_DOWNLOAD`. It also allows the download link to be encompassed in single or double quotes.

I've tested on my Mac that `u3d available -o linux` responds with the latest version and extended the rspecs to cover this case. I have not yet tested on a linux system that the download and install completes successfully. I will do this when I next have access to a linux system - should be able to on Monday. 