### PR TITLE
u3d/asset: add feature that enables easy inspection of asset in a Unity project

### DIFF
--- a/lib/u3d.rb
+++ b/lib/u3d.rb
@@ -25,6 +25,7 @@ require 'u3d_core'
 require 'u3d/utils'
 require 'u3d/version'
 
+require 'u3d/asset'
 require 'u3d/cache'
 require 'u3d/commands'
 require 'u3d/commands_generator'

--- a/lib/u3d/asset.rb
+++ b/lib/u3d/asset.rb
@@ -31,7 +31,7 @@ module U3d
       end
     end
 
-    attr_accessor :path, :meta_path, :meta, :guid
+    attr_reader :path, :meta_path, :meta, :guid
 
     def initialize(path)
       raise ArgumentError, "No file at #{path}" unless File.exist?(path)

--- a/lib/u3d/asset.rb
+++ b/lib/u3d/asset.rb
@@ -42,11 +42,17 @@ module U3d
     end
 
     def guid_references
-      @guid_references ||= `grep -rl #{@guid} Assets/`.split("\n").reject { |f| f == @meta_path }.map { |path| Asset.new(path) }
+      @guid_references ||= U3dCore::CommandExecutor.execute(
+        command: "grep -rl #{@guid} Assets/",
+        print_command: false
+      ).split("\n").reject { |f| f == @meta_path }.map { |path| Asset.new(path) }
     end
 
     def name_references
-      @name_references ||= `grep -rl #{File.basename(@path, extension)} Assets/ --include=*.cs`.split("\n").reject { |f| f == @meta_path }.map { |path| Asset.new(path) }
+      @name_references ||= U3dCore::CommandExecutor.execute(
+        command: "grep -rl #{File.basename(@path, extension)} Assets/ --include=*.cs",
+        print_command: false
+      ).split("\n").map { |path| Asset.new(path) }
     end
 
     def extension

--- a/lib/u3d/asset.rb
+++ b/lib/u3d/asset.rb
@@ -34,7 +34,7 @@ module U3d
     attr_accessor :path, :meta_path, :meta, :guid
 
     def initialize(path)
-      raise "No file at #{path}" unless File.exist?(path)
+      raise ArgumentError, "No file at #{path}" unless File.exist?(path)
       @path = path
       @meta_path = path + ".meta"
       @meta = File.read(@meta_path)

--- a/lib/u3d/asset.rb
+++ b/lib/u3d/asset.rb
@@ -40,12 +40,12 @@ module U3d
       @guid = YAML.safe_load(File.read(@meta_path))['guid']
     end
 
-    def users
-      @users ||= `grep -rl #{@guid} Assets/`.split("\n").reject { |f| f == @meta_path }.map { |path| Asset.new(path) }
+    def guid_references
+      @guid_references ||= `grep -rl #{@guid} Assets/`.split("\n").reject { |f| f == @meta_path }.map { |path| Asset.new(path) }
     end
 
-    def name_reference_users
-      @nr_users ||= `grep -rl #{File.basename(@path, extension)} Assets/ --include=*.cs`.split("\n").reject { |f| f == @meta_path }.map { |path| Asset.new(path) }
+    def name_references
+      @name_references ||= `grep -rl #{File.basename(@path, extension)} Assets/ --include=*.cs`.split("\n").reject { |f| f == @meta_path }.map { |path| Asset.new(path) }
     end
 
     def extension

--- a/lib/u3d/asset.rb
+++ b/lib/u3d/asset.rb
@@ -31,13 +31,14 @@ module U3d
       end
     end
 
-    attr_accessor :path, :meta_path, :guid
+    attr_accessor :path, :meta_path, :meta, :guid
 
     def initialize(path)
       raise "No file at #{path}" unless File.exist?(path)
       @path = path
       @meta_path = path + ".meta"
-      @guid = YAML.safe_load(File.read(@meta_path))['guid']
+      @meta = File.read(@meta_path)
+      @guid = YAML.safe_load(@meta)['guid']
     end
 
     def guid_references

--- a/lib/u3d/asset.rb
+++ b/lib/u3d/asset.rb
@@ -37,8 +37,8 @@ module U3d
       raise ArgumentError, "No file at #{path}" unless File.exist?(path)
       @path = path
       @meta_path = path + ".meta"
-      @meta = File.read(@meta_path)
-      @guid = YAML.safe_load(@meta)['guid']
+      @meta = YAML.safe_load(File.read(@meta_path))
+      @guid = @meta['guid']
     end
 
     def guid_references

--- a/lib/u3d/asset.rb
+++ b/lib/u3d/asset.rb
@@ -1,0 +1,72 @@
+## --- BEGIN LICENSE BLOCK ---
+# Copyright (c) 2016-present WeWantToKnow AS
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+## --- END LICENSE BLOCK ---
+
+require 'yaml'
+
+module U3d
+  # U3d::Asset provides you with a way to easily manipulate an search for assets in Unity Projects
+  class Asset
+    class << self
+      def glob(pattern)
+        Dir.glob(pattern).map { |path| Asset.new(path) }
+      end
+    end
+
+    attr_accessor :path, :meta_path, :guid
+
+    def initialize(path)
+      raise "No file at #{path}" unless File.exist?(path)
+      @path = path
+      @meta_path = path + ".meta"
+      @guid = YAML.safe_load(File.read(@meta_path))['guid']
+    end
+
+    def users
+      @users ||= `grep -rl #{@guid} Assets/`.split("\n").reject { |f| f == @meta_path }.map { |path| Asset.new(path) }
+    end
+
+    def name_reference_users
+      @nr_users ||= `grep -rl #{File.basename(@path, extension)} Assets/ --include=*.cs`.split("\n").reject { |f| f == @meta_path }.map { |path| Asset.new(path) }
+    end
+
+    def extension
+      File.extname(@path)
+    end
+
+    def eql?(other)
+      return false unless other.is_a? Asset
+      other.guid == @guid
+    end
+
+    def hash
+      @guid.to_i
+    end
+
+    def to_s
+      "#{@guid}:#{@path}"
+    end
+
+    def inspect
+      to_s
+    end
+  end
+end

--- a/lib/u3d/asset.rb
+++ b/lib/u3d/asset.rb
@@ -27,7 +27,7 @@ module U3d
   class Asset
     class << self
       def glob(pattern)
-        Dir.glob(pattern).map { |path| Asset.new(path) }
+        Dir.glob(pattern).reject { |path| File.extname(path) == '.meta' || !File.file?(path) }.map { |path| Asset.new(path) }
       end
     end
 

--- a/lib/u3d/unity_project.rb
+++ b/lib/u3d/unity_project.rb
@@ -31,12 +31,20 @@ module U3d
     end
 
     def exist?
-      Dir.exist?("#{@path}/Assets") && Dir.exist?("#{@path}/ProjectSettings")
+      Dir.exist?(assets_path) && Dir.exist?(project_settings_path)
+    end
+
+    def assets_path
+      File.join(@path, 'Assets')
+    end
+
+    def project_settings_path
+      File.join(@path, 'ProjectSettings')
     end
 
     def editor_version
       require 'yaml'
-      project_version = "#{@path}/ProjectSettings/ProjectVersion.txt"
+      project_version = File.join(project_settings_path, 'ProjectVersion.txt')
       return nil unless File.exist? project_version
       yaml = YAML.safe_load(File.read(project_version))
       version = yaml['m_EditorVersion']

--- a/spec/u3d/asset_spec.rb
+++ b/spec/u3d/asset_spec.rb
@@ -1,0 +1,199 @@
+## --- BEGIN LICENSE BLOCK ---
+# Copyright (c) 2016-present WeWantToKnow AS
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+## --- END LICENSE BLOCK ---
+
+require 'u3d/asset'
+require 'yaml'
+
+def mock_file(path, guid, extra_lines = [])
+  allow(File).to receive(:exist?).with(path) { true }
+  allow(File).to receive(:file?).with(path) { true }
+  allow(File).to receive(:read).with(path + '.meta') { (["guid: #{guid}"] | extra_lines).join("\n") }
+end
+
+describe U3d do
+  describe U3d::Asset do
+    before(:each) do
+      # The following lines are necessary or raises rspec errors
+      # See https://github.com/chefspec/chefspec/issues/766
+      allow(File).to receive(:exist?).and_call_original
+      allow(File).to receive(:file?).and_call_original
+      allow(File).to receive(:read).and_call_original
+    end
+
+    describe '#initialize' do
+      context 'when the asset file does not exist' do
+        it 'fails when passed a file that does not exist' do
+          @file = '/some/path.file'
+          expect(File).to receive(:exist?).with(@file) { false }
+
+          expect { U3d::Asset.new(@file) }.to raise_error(ArgumentError)
+        end
+      end
+
+      context 'when the asset file exists' do
+        before(:each) do
+          @file = '/some/path.file'
+          @guid = 'abc123456'
+          mock_file(@file, @guid)
+
+          @asset = U3d::Asset.new(@file)
+        end
+
+        it 'has the correct path' do
+          expect(@asset.path).to eql(@file)
+        end
+
+        it 'has the correct path to the .meta' do
+          expect(@asset.meta_path).to eql(@file + '.meta')
+        end
+
+        it 'successfully retrieves the guid' do
+          expect(@asset.guid).to eql(@guid)
+        end
+
+        it 'stores the parsed meta' do
+          expect(@asset.meta).not_to be_empty
+          expect(@asset.meta).to have_key('guid')
+        end
+      end
+    end
+
+    describe '#guid_references' do
+      it 'retrieves files referencing this asset by guid' do
+        @file = '/some/path.file'
+        @guid = 'abc123456'
+        mock_file(@file, @guid)
+
+        @asset = U3d::Asset.new(@file)
+
+        @reference_a = '/some/reference.A'
+        @guid_reference_a = 'A'
+        @reference_b = '/some/reference.B'
+        @guid_reference_b = 'B'
+
+        mock_file(@reference_a, @guid_reference_a, ["references_sript: #{@guid}"])
+        mock_file(@reference_b, @guid_reference_b, ["references_sript: #{@guid}"])
+
+        allow(U3dCore::CommandExecutor).to receive(:execute) { [@reference_a, @reference_b].join("\n") }
+
+        expect(@asset.guid_references).to satisfy do |list|
+          list.count == 2 &&
+            list.any? { |f| f.path == @reference_a && f.guid == @guid_reference_a } &&
+            list.any? { |f| f.path == @reference_b && f.guid == @guid_reference_b }
+        end
+      end
+    end
+
+    describe '#name_references' do
+      it 'retrieves files referencing this asset by name' do
+        @file = '/some/path.file'
+        @guid = 'abc123456'
+        mock_file(@file, @guid)
+
+        @asset = U3d::Asset.new(@file)
+
+        @reference_a = '/some/reference.A'
+        @guid_reference_a = 'A'
+        @reference_b = '/some/reference.B'
+        @guid_reference_b = 'B'
+
+        mock_file(@reference_a, @guid_reference_a, ["references_sript: #{@guid}"])
+        mock_file(@reference_b, @guid_reference_b, ["references_sript: #{@guid}"])
+
+        allow(U3dCore::CommandExecutor).to receive(:execute) { [@reference_a, @reference_b].join("\n") }
+
+        expect(@asset.guid_references).to satisfy do |list|
+          list.count == 2 &&
+            list.any? { |f| f.path == @reference_a && f.guid == @guid_reference_a } &&
+            list.any? { |f| f.path == @reference_b && f.guid == @guid_reference_b }
+        end
+      end
+    end
+
+    describe '#extension' do
+      it 'gets the correct extension of the asset' do
+        @file = '/some/path.file'
+        @guid = 'abc123456'
+        mock_file(@file, @guid)
+
+        @asset = U3d::Asset.new(@file)
+
+        expect(@asset.extension).to eql('.file')
+      end
+    end
+
+    describe '#to_s' do
+      it 'concatenates the guid and the name of the asset' do
+        @file = '/some/path.file'
+        @guid = 'abc123456'
+        mock_file(@file, @guid)
+
+        @asset = U3d::Asset.new(@file)
+
+        expect(@asset.to_s).to eql([@guid, @file].join(':'))
+      end
+    end
+
+    describe '#inspect' do
+      it 'concatenates the guid and the name of the asset' do
+        @file = '/some/path.file'
+        @guid = 'abc123456'
+        mock_file(@file, @guid)
+
+        @asset = U3d::Asset.new(@file)
+
+        expect(@asset.inspect).to eql([@guid, @file].join(':'))
+      end
+    end
+
+    describe ':glob' do
+      it 'retrieves all assets matching a path pattern' do
+        @file_a = '/some/pathA.file'
+        @guid_a = 'abc123456A'
+        @file_b = '/some/pathB.file'
+        @guid_b = 'abc123456B'
+        mock_file(@file_a, @guid_a)
+        mock_file(@file_b, @guid_b)
+
+        @pattern = '/some/path_*'
+        expect(Dir).to receive(:glob).with(@pattern) { [@file_a, @file_b] }
+
+        expect(U3d::Asset.glob(@pattern)).to satisfy do |list|
+          list.count == 2 &&
+            list.any? { |f| f.path == @file_a && f.guid == @guid_a } &&
+            list.any? { |f| f.path == @file_b && f.guid == @guid_b }
+        end
+      end
+
+      it 'ignores .meta files' do
+        @file = '/some/path.file'
+        @guid = 'abc123456'
+        mock_file(@file, @guid)
+
+        @pattern = '/some/path_*'
+        expect(Dir).to receive(:glob).with(@pattern) { [@file, '/some/path_other.meta'] }
+
+        expect(U3d::Asset.glob(@pattern).count).to eql(1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!--
Thank you for contributing to u3d!
Before you post your pull request, please make sure that you checked the boxes! (put an x in the [ ] without spaces)
If possible, try to name your pull request by prefixing it with <SUBJECT>. For instance, if you're modifying the downloading, you could prefix it with u3d/download:
-->

### Pull Request Checklist

- [x] My pull request has been rebased on master
- [x] I ran `bundle exec rspec` to make sure that my PR didn't break any test
- [x] I ran `bundle exec rubocop` to make sure that my PR is inline with our code style
- [x] I have read the [code of conduct](https://github.com/DragonBox/u3d/blob/master/CODE_OF_CONDUCT.md)

### Pull Request Description

This is some work I have done recently to look for asset usage in a Unity project, and I believe it belongs in u3d. It enables one to easily browse the asset in his project and find how they reference one another, either by guid or by name.

Sample command possible:
```
$ u3d console
Welcome to u3d interactive!
>> U3d::Asset.glob('Assets/Some/Path/*').map {|asset| asset.users}.flatten.uniq
[...]
```

Which is quite useful in my opinion and makes for a powerful debugging tool.