### PR TITLE
Add `-t*` flag for 7z when unpacking packages

### DIFF
--- a/lib/u3d/installer.rb
+++ b/lib/u3d/installer.rb
@@ -285,7 +285,7 @@ module U3d
       Dir.mktmpdir do |tmp_dir|
         UI.verbose "Working in tmp dir #{tmp_dir}"
 
-        command = "7z -aos -o#{tmp_dir.shellescape} e #{file.shellescape}"
+        command = "7z -aos -t* -o#{tmp_dir.shellescape} e #{file.shellescape}"
         U3dCore::CommandExecutor.execute(command: command)
 
         target_location = pkg_install_path(installation_path, "#{tmp_dir}/PackageInfo")


### PR DESCRIPTION
<!--
Thank you for contributing to u3d!
Before you post your pull request, please make sure that you checked the boxes! (put an x in the [ ] without spaces)
If possible, try to name your pull request by prefixing it with <SUBJECT>. For instance, if you're modifying the downloading, you could prefix it with u3d/download:
-->

### Pull Request Checklist

- [x] My pull request has been rebased on master
- [x] I ran `bundle exec rspec` to make sure that my PR didn't break any test
- [x] I ran `bundle exec rubocop` to make sure that my PR is inline with our code style
- [x] I have read the [code of conduct](https://github.com/DragonBox/u3d/blob/master/CODE_OF_CONDUCT.md)

### Pull Request Description

Fixes #310 by adding `-t*` to the 7z `command`. Thanks to @jsmouret-vl for posting the fix in the issue. Tested and working on linux to install Android support, where it was broken for me, prompting the PR.