### PR TITLE
list/available: find Mac or Windows version based on the unity_shader package. Fixes #349

### DIFF
--- a/lib/u3d/unity_versions.rb
+++ b/lib/u3d/unity_versions.rb
@@ -122,9 +122,9 @@ module U3d
     #####################################################
     # Captures a version and its base url
     LINUX_DOWNLOAD = %r{['"](https?:\/\/[\w/\.-]+/[0-9a-f\+]{12,13}\/)(.\/)?UnitySetup-(\d+\.\d+\.\d+\w\d+)['"]}
-    MAC_DOWNLOAD = %r{"(https?://[\w/\.-]+/[0-9a-f\+]{12,13}/)MacEditorInstaller/[a-zA-Z0-9/\.\+]+-(\d+\.\d+\.\d+\w\d+)\.?\w+"}
-    MAC_DOWNLOAD_2018_2 = %r{"(https?://[\w/\.-]+/[0-9a-f\+]{12,13}/)UnityDownloadAssistant-(\d+\.\d+\.\d+\w\d+)\.?\w+"}
-    WIN_DOWNLOAD = %r{"(https?://[\w/\.-]+/[0-9a-f\+]{12,13}/)Windows..EditorInstaller/[a-zA-Z0-9/\.\+]+-(\d+\.\d+\.\d+\w\d+)\.?\w+"}
+
+    MAC_WIN_SHADERS = %r{"(https?://[\w/\.-]+/[0-9a-f\+]{12,13}/)builtin_shaders-(\d+\.\d+\.\d+\w\d+)\.?\w+"}
+
     LINUX_DOWNLOAD_DATED = %r{"(https?://[\w/\._-]+/unity\-editor\-installer\-(\d+\.\d+\.\d+\w\d+).*\.sh)"}
     LINUX_DOWNLOAD_RECENT_PAGE = %r{"(https?://beta\.unity3d\.com/download/[a-zA-Z0-9/\.\+]+/public_download\.html)"}
     LINUX_DOWNLOAD_RECENT_FILE = %r{'(https?://beta\.unity3d\.com/download/[a-zA-Z0-9/\.\+]+/unity\-editor\-installer\-(\d+\.\d+\.\d+(?:x)?\w\d+).*\.sh)'}
@@ -287,7 +287,7 @@ module U3d
     class MacVersions
       class << self
         def list_available
-          versions_fetcher = VersionsFetcher.new(pattern: [MAC_DOWNLOAD, MAC_DOWNLOAD_2018_2])
+          versions_fetcher = VersionsFetcher.new(pattern: [MAC_WIN_SHADERS])
           versions_fetcher.fetch_all_channels
           versions_fetcher.fetch_json('darwin')
         end
@@ -297,7 +297,7 @@ module U3d
     class WindowsVersions
       class << self
         def list_available
-          versions_fetcher = VersionsFetcher.new(pattern: WIN_DOWNLOAD)
+          versions_fetcher = VersionsFetcher.new(pattern: MAC_WIN_SHADERS)
           versions_fetcher.fetch_all_channels
           versions_fetcher.fetch_json('win32')
         end

--- a/spec/support/download_archives.rb
+++ b/spec/support/download_archives.rb
@@ -21,19 +21,14 @@
 ## --- END LICENSE BLOCK ---
 
 # Various fake download archives
-def windows_archive
+def macosx_windows_archive
   %(
-    <li><a href="http://download.unity3d.com/download_unity/d3101c3b8468/Windows64EditorInstaller/UnitySetup64-1.2.3f1.exe">Éditeur 64 bits</a></li>
-    <li><a href="http://download.unity3d.com/download_unity/d3101c3b8468/Windows64EditorInstaller/UnitySetup64-1.3.5f1.exe">Éditeur 64 bits</a></li>
-    <li><a href="http://download.unity3d.com/download_unity/d3101c3b8468/Windows64EditorInstaller/UnitySetup64-2017.1.6f1.exe">Éditeur 64 bits</a></li>
-  )
-end
-
-def macosx_archive
-  %(
-    <li><a href="http://download.unity3d.com/download_unity/d3101c3b8468/MacEditorInstaller/Unity-1.2.3f1.pkg">Éditeur Unity</a></li>
-    <li><a href="http://download.unity3d.com/download_unity/d3101c3b8468/MacEditorInstaller/Unity-1.3.5f1.pkg">Éditeur Unity</a></li>
-    <li><a href="http://download.unity3d.com/download_unity/d3101c3b8468/MacEditorInstaller/Unity-2017.1.6f1.pkg">Éditeur Unity</a></li>
+    <li><a href="https://download.unity3d.com/download_unity/builtin_shaders-4.7.2.zip">Shaders</a></li>
+    <li><a href="https://download.unity3d.com/download_unity/builtin_shaders-4.7.2.zip">Shaders</a></li>
+    <li><a href="https://download.unity3d.com/download_unity/6bac21139588/builtin_shaders-5.6.6f2.zip">Shaders</a></li>
+    <li><a href="https://download.unity3d.com/download_unity/6bac21139588/builtin_shaders-5.6.6f2.zip">Shaders</a></li>
+    <li><a href="https://netstorage.unity3d.com/unity/9e14d22a41bb/builtin_shaders-2018.3.7f1.zip"></a></li>
+    <li><a href="https://netstorage.unity3d.com/unity/9e14d22a41bb/builtin_shaders-2018.3.7f1.zip"></a></li>
   )
 end
 

--- a/spec/u3d/unity_versions_spec.rb
+++ b/spec/u3d/unity_versions_spec.rb
@@ -45,14 +45,9 @@ describe U3d do
     end
 
     describe '.fetch_version' do
-      it 'reads versions for windows' do
-        expect(U3d::Utils).to receive(:get_ssl) { windows_archive }
-        expect(U3d::UnityVersions.fetch_version("foo", U3d::UnityVersions::WIN_DOWNLOAD).count).to eql 3
-      end
-
-      it 'reads versions for mac' do
-        expect(U3d::Utils).to receive(:get_ssl) { macosx_archive }
-        expect(U3d::UnityVersions.fetch_version("foo", U3d::UnityVersions::MAC_DOWNLOAD).count).to eql 3
+      it 'reads versions for windows and mac' do
+        expect(U3d::Utils).to receive(:get_ssl) { macosx_windows_archive }
+        expect(U3d::UnityVersions.fetch_version("foo", U3d::UnityVersions::MAC_WIN_SHADERS).count).to eql 2
       end
     end
 
@@ -80,8 +75,8 @@ describe U3d do
         expect(U3d::UnityVersions.list_available(os: :win).count).to eql 0
       end
       it 'retrieves mac versions' do
-        expect(U3d::UnityVersions).to receive(:fetch_version_paged).at_least(6).times { {} }
-        expect(U3d::UnityVersions).to receive(:fetch_version).at_least(6).times { {} }
+        expect(U3d::UnityVersions).to receive(:fetch_version_paged).at_least(3).times { {} }
+        expect(U3d::UnityVersions).to receive(:fetch_version).at_least(3).times { {} }
         expect(U3d::UnityVersions).to receive(:fetch_from_json).at_least(:once) { {} }
         expect(U3d::UnityVersions.list_available(os: :mac).count).to eql 0
       end


### PR DESCRIPTION
More stable and finds both older and newer versions that are dependent on the DownloadAssistant


<!--
Thank you for contributing to u3d!
Before you post your pull request, please make sure that you checked the boxes! (put an x in the [ ] without spaces)
If possible, try to name your pull request by prefixing it with <SUBJECT>. For instance, if you're modifying the downloading, you could prefix it with u3d/download:
-->

### Pull Request Checklist

- [x] My pull request has been rebased on master
- [x] I ran `bundle exec rspec` to make sure that my PR didn't break any test
- [x] I ran `bundle exec rubocop` to make sure that my PR is inline with our code style
- [x] I have read the [code of conduct](https://github.com/DragonBox/u3d/blob/master/CODE_OF_CONDUCT.md)