### PR TITLE
Use the VersionsFetcher with Unity's json on Linux as well

### DIFF
--- a/lib/u3d/unity_versions.rb
+++ b/lib/u3d/unity_versions.rb
@@ -124,6 +124,7 @@ module U3d
     LINUX_DOWNLOAD = %r{['"](https?:\/\/[\w/\.-]+/[0-9a-f\+]{12,13}\/)(.\/)?UnitySetup-(\d+\.\d+\.\d+\w\d+)['"]}
 
     MAC_WIN_SHADERS = %r{"(https?://[\w/\.-]+/[0-9a-f\+]{12,13}/)builtin_shaders-(\d+\.\d+\.\d+\w\d+)\.?\w+"}
+    LINUX_INSTALLER = %r{(https?://[\w/\.-]+/[0-9a-f\+]{12,13}/)LinuxEditorInstaller/Unity.tar.xz}
 
     LINUX_DOWNLOAD_DATED = %r{"(https?://[\w/\._-]+/unity\-editor\-installer\-(\d+\.\d+\.\d+\w\d+).*\.sh)"}
     LINUX_DOWNLOAD_RECENT_PAGE = %r{"(https?://beta\.unity3d\.com/download/[a-zA-Z0-9/\.\+]+/public_download\.html)"}
@@ -191,6 +192,10 @@ module U3d
           versions = @unity_forums.pagination_urls(UNITY_LINUX_DOWNLOADS).map do |page_url|
             list_available_from_page(@unity_forums, unity_forums.page_content(page_url))
           end.reduce({}, :merge)
+
+          versions_fetcher = VersionsFetcher.new(pattern: LINUX_INSTALLER)
+          versions.merge!(versions_fetcher.fetch_json('linux'))
+
           if versions.count.zero?
             UI.important 'Found no releases'
           else

--- a/spec/support/download_archives.rb
+++ b/spec/support/download_archives.rb
@@ -90,6 +90,35 @@ def latest_macosx_archive
   )
 end
 
+def latest_linux_archive
+  %(
+    {
+      "official": [
+        {
+          "version": "2017.4.29f1",
+          "lts": true,
+          "downloadUrl": "https://download.unity3d.com/download_unity/06508aa14ca1/LinuxEditorInstaller/Unity.tar.xz",
+          "downloadSize": 676983480,
+          "installedSize": 2790574080,
+          "checksum": "05e8bbe78c84fe7bda272753364a5bc3",
+          "modules": []
+        }
+      ],
+      "beta": [
+        {
+          "version": "2019.2.0b7",
+          "lts": false,
+          "downloadUrl": "https://beta.unity3d.com/download/87c9ecb96495/LinuxEditorInstaller/Unity.tar.xz",
+          "downloadSize": 974682112,
+          "installedSize": 3383275520,
+          "checksum": "4bcd2eff7ab0e3894513c89e7fce51cc",
+          "modules": []
+        }
+      ]
+    }
+      )
+end
+
 def linux_archive_old
   %(
     <b>5.4.0b10</b>: <a href="http://download.unity3d.com/download_unity/linux/unity-editor-installer-1.2.3f1+20160316.sh" target="_blank" class="externalLink">http://download.unity3d.com/download_unity/linux/unity-editor-installer-1.2.3f1+20160316.sh</a><br />

--- a/spec/u3d/unity_versions_spec.rb
+++ b/spec/u3d/unity_versions_spec.rb
@@ -98,8 +98,9 @@ describe U3d do
           allow(U3d::Utils).to receive(:get_url_content_length).with(/download.un.*1.2.3f1/) { 1005 }
           allow(U3d::Utils).to receive(:get_url_content_length).with(/download.un.*1.3.5f1/) { 1006 }
           allow(U3d::Utils).to receive(:get_url_content_length).with(/download.un.*2017.1.6f1/) { 1007 }
+          expect(U3d::Utils).to receive(:get_ssl) { latest_linux_archive }
 
-          expect(U3d::UnityVersions.list_available(os: :linux).keys).to eql ['1.2.3f1', '1.3.5f1', '2017.1.6f1']
+          expect(U3d::UnityVersions.list_available(os: :linux).keys).to eql ['1.2.3f1', '1.3.5f1', '2017.1.6f1', '2017.4.29f1', '2019.2.0b7']
         end
 
         it 'retrieves nested and packaged linux versions' do
@@ -114,8 +115,9 @@ describe U3d do
           allow(U3d::INIparser).to receive(:load_ini).with('2017.1.0b3', nil, os: :linux, offline: true) {}
           allow(U3d::INIparser).to receive(:load_ini).with('2017.3.0f1', nil, os: :linux, offline: true) {}
           allow(U3d::INIparser).to receive(:load_ini).with('2017.2.1f1', nil, os: :linux, offline: true) {}
+          expect(U3d::Utils).to receive(:get_ssl) { latest_linux_archive }
 
-          expect(U3d::UnityVersions.list_available(os: :linux).keys).to eql ['1.2.3f1', '1.3.5f1', '2017.1.6f1', '2018.3.0f2', '2017.1.0b3', '2017.3.0f1', '2017.2.1f1']
+          expect(U3d::UnityVersions.list_available(os: :linux).keys).to eql ['1.2.3f1', '1.3.5f1', '2017.1.6f1', '2018.3.0f2', '2017.1.0b3', '2017.3.0f1', '2017.2.1f1', '2017.4.29f1', '2019.2.0b7']
         end
       end
     end


### PR DESCRIPTION
<!--
Thank you for contributing to u3d!
Before you post your pull request, please make sure that you checked the boxes! (put an x in the [ ] without spaces)
If possible, try to name your pull request by prefixing it with <SUBJECT>. For instance, if you're modifying the downloading, you could prefix it with u3d/download:
-->

### Pull Request Checklist

- [x] My pull request has been rebased on master
- [x] I ran `bundle exec rspec` to make sure that my PR didn't break any test
- [x] I ran `bundle exec rubocop` to make sure that my PR is inline with our code style
- [x] I have read the [code of conduct](https://github.com/DragonBox/u3d/blob/master/CODE_OF_CONDUCT.md)

### Pull Request Description

<!-- If this pull request is related to a specific issue, please specify here "Fixes #ISSUE_NO" -->
<!-- Please describe your pull request with as much precision as possible. Write here why you think this change is required, what problem it solves, how it solves it...  -->
<!-- Please describe to what extent you tested your modifications -->
Fixes #360  by using the same mechanism of fetching Unity's json manifest to retrieve missing Unity versions.

Tested with `u3d available -f --no-central -o linux`

Result:
```
paulniezborala@Pauls-MBP u3d (master) $ git diff --no-index current.versions newer.versions
diff --git a/current.versions b/newer.versions
index 0950a87..1a001e6 100644
--- a/current.versions
+++ b/newer.versions
@@ -2,7 +2,7 @@
 Loading Unity releases
 Loading Unity latest releases
 Found 7 latest releases.
-Found 84 releases.
+Found 91 releases.
 Version 5.1.0f3: http://download.unity3d.com/download_unity/unity-editor-installer-5.1.0f3+2015091501.sh
 Version 5.2.2f1: http://files.unity3d.com/levi/unity-editor-installer-5.2.2f1+20151018.sh
 Version 5.3.0f4: http://download.unity3d.com/download_unity/linux/unity-editor-installer-5.3.0f4+20151218.sh
@@ -66,6 +66,7 @@ Version 2017.4.7f1: https://beta.unity3d.com/download/1d86eef80e0a/
 Version 2017.4.8f1: https://beta.unity3d.com/download/8140fe378247/
 Version 2017.4.9f1: https://beta.unity3d.com/download/cc814e4d942d/
 Version 2017.4.10f1: https://beta.unity3d.com/download/14396d76537e/
+Version 2017.4.29f1: https://download.unity3d.com/download_unity/06508aa14ca1/
 Version 2018.1.0b8: https://beta.unity3d.com/download/ee2fb9f9da52/
 Version 2018.1.0b13: https://beta.unity3d.com/download/77a142ac9989/
 Version 2018.1.0f2: https://beta.unity3d.com/download/170f0691b973/
@@ -85,5 +86,11 @@ Version 2018.2.4f1: https://beta.unity3d.com/download/fe703c5165de/
 Version 2018.2.5f1: https://beta.unity3d.com/download/88f43da96871/
 Version 2018.2.6f1: https://beta.unity3d.com/download/793261fe3e9a/
 Version 2018.2.7f1: https://beta.unity3d.com/download/dad990bf2728/
+Version 2018.2.21f1: https://download.unity3d.com/download_unity/a122f5dc316d/
 Version 2018.3.0f2: https://beta.unity3d.com/download/6e9a27477296/
+Version 2018.3.14f1: https://download.unity3d.com/download_unity/d0e9f15437b1/
+Version 2018.4.3f1: https://download.unity3d.com/download_unity/8a9509a5aff9/
 Version 2019.1.0f2: http://beta.unity3d.com/download/292b93d75a2c/
+Version 2019.1.8f1: https://download.unity3d.com/download_unity/7938dd008a75/
+Version 2019.2.0b7: https://beta.unity3d.com/download/87c9ecb96495/
+Version 2019.3.0a8: https://beta.unity3d.com/download/8ea4afdbfa47/
```