### PR TITLE
u3d/installer: support custom install paths through U3D_EXTRA_PATHS

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,14 @@ You can get further information on how to use U3d by running `u3d --help` (or `u
 
 ## How-tos
 
+### Install in a custom location
+
+`u3d install` accepts an argument `--installation_path` which can install unity and its additional components to the location you want.
+
+However, there is a pitfall to that: you need to tell u3d where to look for the versions you installed in custom location. Doing so is quite easy, you just have to set the `U3D_EXTRA_PATHS`, to a list of paths that you want u3d to look for versions.
+
+_NOTE:_ The list of paths `U3D_EXTRA_PATHS` is formatted as your standard `PATH`, ie `U3D_EXTRA_PATHS=/path/to/something:/another/path` on Unix systems, and `U3D_EXTRA_PATHS=C:\Path\To\Something;E:\Another\Path` on Windows.
+
 ### Run several Unity instances in parallel
 
 The only thing you have to watch for while trying to run multiple instances of Unity in parallel is the fact that they will share the same log file by default (the `Editor.log`). Therefore you will have to specify it using the [command line arguments](https://docs.unity3d.com/Manual/CommandLineArguments.html), you can do so with u3d the following way from each of your project root folder:

--- a/lib/u3d/installer.rb
+++ b/lib/u3d/installer.rb
@@ -94,8 +94,8 @@ module U3d
       ENV['U3D_EXTRA_PATHS'].strip.split(File::PATH_SEPARATOR)
     end
 
-    def find_installations_with_path(default_path, *postfix)
-      ([default_path] | extra_installation_paths).map do |path|
+    def find_installations_with_path(default_root_path: '', postfix: [])
+      ([default_root_path] | extra_installation_paths).map do |path|
         UI.verbose "Looking for installed Unity version under #{path}"
         pattern = File.join([path] + postfix)
         Dir.glob(pattern).map { |found_path| yield found_path }
@@ -185,10 +185,12 @@ module U3d
 
     def list_installed_paths
       paths = find_installations_with_path(
-        DEFAULT_MAC_INSTALL,
-        'Applications',
-        'Unity*',
-        'Unity.app'
+        default_root_path: DEFAULT_MAC_INSTALL,
+        postfix: %w[
+          Applications
+          Unity*
+          Unity.app
+        ]
       ) { |u| Pathname.new(u).parent.to_s }
       UI.verbose "Found list_installed_paths: #{paths}"
       paths
@@ -351,9 +353,11 @@ module U3d
 
     def list_installed_paths
       paths = find_installations_with_path(
-        DEFAULT_LINUX_INSTALL,
-        'unity-editor-*',
-        'Editor'
+        default_root_path: DEFAULT_LINUX_INSTALL,
+        postfix: %w[
+          unity-editor-*
+          Editor
+        ]
       ) { |u| Pathname.new(u).parent.to_s }
       UI.verbose "Found list_installed_paths: #{paths}"
       paths
@@ -361,9 +365,11 @@ module U3d
 
     def debian_installed_paths
       paths = find_installations_with_path(
-        DEFAULT_LINUX_INSTALL,
-        'Unity',
-        'Editor'
+        default_root_path: DEFAULT_LINUX_INSTALL,
+        postfix: %w[
+          Unity
+          Editor
+        ]
       ) { |u| Pathname.new(u).parent.to_s }
       UI.verbose "Found debian_installed_paths: #{paths}"
       paths
@@ -385,10 +391,12 @@ module U3d
 
     def installed
       find_installations_with_path(
-        DEFAULT_MAC_INSTALL,
-        'Unity*',
-        'Editor',
-        'Uninstall.exe'
+        default_root_path: DEFAULT_MAC_INSTALL,
+        postfix: %w[
+          Unity*
+          Editor
+          Uninstall.exe
+        ]
       ) { |path| WindowsInstallation.new(root_path: File.expand_path('../..', path)) }
     end
 

--- a/lib/u3d/installer.rb
+++ b/lib/u3d/installer.rb
@@ -188,7 +188,8 @@ module U3d
         DEFAULT_MAC_INSTALL,
         'Applications',
         'Unity*',
-        'Unity.app') { |u| Pathname.new(u).parent.to_s }
+        'Unity.app'
+      ) { |u| Pathname.new(u).parent.to_s }
       UI.verbose "Found list_installed_paths: #{paths}"
       paths
     end
@@ -352,7 +353,8 @@ module U3d
       paths = find_installations_with_path(
         DEFAULT_LINUX_INSTALL,
         'unity-editor-*',
-        'Editor') { |u| Pathname.new(u).parent.to_s }
+        'Editor'
+      ) { |u| Pathname.new(u).parent.to_s }
       UI.verbose "Found list_installed_paths: #{paths}"
       paths
     end
@@ -384,7 +386,8 @@ module U3d
         DEFAULT_MAC_INSTALL,
         'Unity*',
         'Editor',
-        'Uninstall.exe') { |path| WindowsInstallation.new(root_path: File.expand_path('../..', path)) }
+        'Uninstall.exe'
+      ) { |path| WindowsInstallation.new(root_path: File.expand_path('../..', path)) }
     end
 
     def install(file_path, version, installation_path: nil, info: {})

--- a/lib/u3d/installer.rb
+++ b/lib/u3d/installer.rb
@@ -391,7 +391,7 @@ module U3d
 
     def installed
       find_installations_with_path(
-        default_root_path: DEFAULT_MAC_INSTALL,
+        default_root_path: DEFAULT_WINDOWS_INSTALL,
         postfix: %w[
           Unity*
           Editor

--- a/lib/u3d/installer.rb
+++ b/lib/u3d/installer.rb
@@ -360,9 +360,11 @@ module U3d
     end
 
     def debian_installed_paths
-      find = File.join(DEFAULT_LINUX_INSTALL, 'Unity', 'Editor')
-      paths = Dir[find]
-      paths = paths.map { |u| Pathname.new(u).parent.to_s }
+      paths = find_installations_with_path(
+        DEFAULT_LINUX_INSTALL,
+        'Unity',
+        'Editor'
+      ) { |u| Pathname.new(u).parent.to_s }
       UI.verbose "Found debian_installed_paths: #{paths}"
       paths
     end

--- a/lib/u3d/installer.rb
+++ b/lib/u3d/installer.rb
@@ -91,7 +91,7 @@ module U3d
 
     def extra_installation_paths
       return [] if ENV['U3D_EXTRA_PATHS'].nil?
-      ENV['U3D_EXTRA_PATHS'].strip.split(';')
+      ENV['U3D_EXTRA_PATHS'].strip.split(File::PATH_SEPARATOR)
     end
 
     def find_installations_with_path(default_path, *postfix)

--- a/spec/support/installations.rb
+++ b/spec/support/installations.rb
@@ -31,6 +31,16 @@ def macinstall_5_6_default
   return unity
 end
 
+def macinstall_5_6_custom_location
+  unity = double("MacInstallation")
+  # allow(unity).to receive(:path) { '/Applications/Unity/Unity.app' }
+  allow(unity).to receive(:version) { '5.6.0f1' }
+  allow(unity).to receive(:build_number) { 'bf5cca3e2788' }
+  allow(unity).to receive(:clean_install?) { false }
+  allow(unity).to receive(:root_path) { '/tmp/Applications/Unity' }
+  return unity
+end
+
 def macinstall_5_6_custom_with_space
   unity = double("MacInstallation")
   # allow(unity).to receive(:path) { '/Applications/Unity 5.6.0f1/Unity.app' }
@@ -86,6 +96,15 @@ def windows_2017_1_64bits_renamed
   allow(unity).to receive(:version) { '2017.1.0f3' }
   allow(unity).to receive(:build_number) { '472613c02cf7' }
   allow(unity).to receive(:root_path) { 'C:/Program Files/Unity_2017.1.0f3' }
+  return unity
+end
+
+def windows_2017_1_64bits_custom_location
+  unity = double("WindowsInstallation")
+  # allow(unity).to receive(:path) { 'C:/Program Files/Unity_2017.1.0f3' }
+  allow(unity).to receive(:version) { '2017.1.0f3' }
+  allow(unity).to receive(:build_number) { '472613c02cf7' }
+  allow(unity).to receive(:root_path) { 'E:/Program Files/Unity_2017.1.0f3' }
   return unity
 end
 

--- a/spec/u3d/installer_spec.rb
+++ b/spec/u3d/installer_spec.rb
@@ -91,6 +91,59 @@ describe U3d do
     end
 
     describe U3d::MacInstaller, unless: WINDOWS do
+      describe '.list' do
+        it 'finds installs in default locations' do
+          unity = macinstall_5_6_default
+          installer = U3d::MacInstaller.new
+
+          allow(Dir).to receive(:glob).with('/Applications/Unity*/Unity.app') { ["#{unity.root_path}/Unity.app"] }
+          allow(U3d::MacInstallation).to receive(:new).with(root_path: unity.root_path) { unity }
+          allow(installer).to receive(:spotlight_installed_paths) { [] }
+
+          expect(installer.installed).to eql [unity]
+        end
+
+        it 'does not find installs in custom locations without U3D_EXTRA_PATHS' do
+          unity = macinstall_5_6_custom_location
+          installer = U3d::MacInstaller.new
+
+          allow(Dir).to receive(:glob).with('/Applications/Unity*/Unity.app') { [] }
+          allow(Dir).to receive(:glob).with('/tmp/Applications/Unity*/Unity.app') { ["#{unity.root_path}/Unity.app"] }
+          allow(U3d::MacInstallation).to receive(:new).with(root_path: unity.root_path) { unity }
+          allow(installer).to receive(:spotlight_installed_paths) { [] }
+
+          expect(installer.installed).to eql []
+        end
+
+        it 'finds installs in custom locations with U3D_EXTRA_PATHS' do
+          unity = macinstall_5_6_custom_location
+          installer = U3d::MacInstaller.new
+
+          allow(ENV).to receive(:[]).with('U3D_EXTRA_PATHS') { '/tmp' }
+          allow(Dir).to receive(:glob).with('/Applications/Unity*/Unity.app') { [] }
+          allow(Dir).to receive(:glob).with('/tmp/Applications/Unity*/Unity.app') { ["#{unity.root_path}/Unity.app"] }
+          allow(U3d::MacInstallation).to receive(:new).with(root_path: unity.root_path) { unity }
+          allow(installer).to receive(:spotlight_installed_paths) { [] }
+
+          expect(installer.installed).to eql [unity]
+        end
+
+        it 'finds both custom and default installs' do
+          unity_default = macinstall_5_6_default
+          unity_custom = macinstall_5_6_custom_location
+          installer = U3d::MacInstaller.new
+
+          allow(ENV).to receive(:[]).with('U3D_EXTRA_PATHS') { '/tmp' }
+          allow(Dir).to receive(:glob).with('/Applications/Unity*/Unity.app') { ["#{unity_default.root_path}/Unity.app"] }
+          allow(Dir).to receive(:glob).with('/tmp/Applications/Unity*/Unity.app') { ["#{unity_custom.root_path}/Unity.app"] }
+          allow(U3d::MacInstallation).to receive(:new).with(root_path: unity_default.root_path) { unity_default }
+          allow(U3d::MacInstallation).to receive(:new).with(root_path: unity_custom.root_path) { unity_custom }
+          allow(installer).to receive(:spotlight_installed_paths) { [] }
+
+          expect(installer.installed).to eql [unity_default, unity_custom]
+        end
+      end
+
       context 'when using a default install' do
         let(:unity) { macinstall_5_6_default }
         it 'sanitizes install' do

--- a/spec/u3d/installer_spec.rb
+++ b/spec/u3d/installer_spec.rb
@@ -180,8 +180,8 @@ describe U3d do
           u1 = linux_5_6_standard
           u2 = linux_5_6_debian
           u3 = linux_2017_1_weird
-          allow(Dir).to receive(:[]).with('/opt/unity-editor-*/Editor') { ["#{u1.root_path}/Editor", "#{u3.root_path}/Editor"] }
-          allow(Dir).to receive(:[]).with('/opt/Unity/Editor') { ["#{u2.root_path}/Editor"] }
+          allow(Dir).to receive(:glob).with('/opt/unity-editor-*/Editor') { ["#{u1.root_path}/Editor", "#{u3.root_path}/Editor"] }
+          allow(Dir).to receive(:glob).with('/opt/Unity/Editor') { ["#{u2.root_path}/Editor"] }
 
           allow(U3d::LinuxInstallation).to receive(:new).with(root_path: u1.root_path) { u1 }
           allow(U3d::LinuxInstallation).to receive(:new).with(root_path: u2.root_path) { u2 }


### PR DESCRIPTION
<!--
Thank you for contributing to u3d!
Before you post your pull request, please make sure that you checked the boxes! (put an x in the [ ] without spaces)
If possible, try to name your pull request by prefixing it with <SUBJECT>. For instance, if you're modifying the downloading, you could prefix it with u3d/download:
-->

### Pull Request Checklist

- [x] My pull request has been rebased on master
- [x] I ran `bundle exec rspec` to make sure that my PR didn't break any test
- [x] I ran `bundle exec rubocop` to make sure that my PR is inline with our code style
- [x] I have read the [code of conduct](https://github.com/DragonBox/u3d/blob/master/CODE_OF_CONDUCT.md)

### Pull Request Description

<!-- If this pull request is related to a specific issue, please specify here "Fixes #ISSUE_NO" -->
<!-- Please describe your pull request with as much precision as possible. Write here why you think this change is required, what problem it solves, how it solves it...  -->
<!-- Please describe to what extent you tested your modifications -->

`u3d install` supports custom installation paths, but does not list them correctly in the rest of the application.
This means that `u3d run`, package installs and such commands will not detect properly the version installed in a custom path.

This fixes this behaviour by adding an environment variable `U3D_EXTRA_PATHS` which is a list of additional paths to look for installed Unity versions.

Fixes #370 
Fixes #371