### PR TITLE
u3d/installation: fix the version retrieving for Windows on Unity 2019.2.x and onwards

### DIFF
--- a/lib/u3d/installation.rb
+++ b/lib/u3d/installation.rb
@@ -430,7 +430,7 @@ module U3d
     end
 
     private
-    
+
     def helper
       @helper ||= WindowsInstallationHelper.new(exe_path)
     end

--- a/lib/u3d/installation.rb
+++ b/lib/u3d/installation.rb
@@ -364,7 +364,7 @@ module U3d
 
   class WindowsInstallation < Installation
     def version
-      version = @helper.version
+      version = helper.version
       return version unless version.nil?
 
       path = "#{root_path}/Editor/Data/"
@@ -374,7 +374,7 @@ module U3d
     end
 
     def build_number
-      @helper.build_number
+      helper.build_number
     end
 
     def default_log_file

--- a/lib/u3d/installation.rb
+++ b/lib/u3d/installation.rb
@@ -296,8 +296,21 @@ module U3d
   end
 
   class WindowsInstallationHelper
-    def build_number(exe_path)
-      s = string_file_info("Unity Version", exe_path)
+    def initialize(exe_path)
+      @exe_path = exe_path
+    end
+
+    def version
+      s = unity_version_info
+      if s
+        a = s.split("_")
+        return a[0] unless a.empty?
+      end
+      nil
+    end
+
+    def build_number
+      s = unity_version_info
       if s
         a = s.split("_")
         return a[1] if a.count > 1
@@ -306,6 +319,10 @@ module U3d
     end
 
     private
+
+    def unity_version_info
+      @uvf ||= string_file_info('Unity Version', @exe_path)
+    end
 
     def string_file_info(info, path)
       require "Win32API"
@@ -347,6 +364,9 @@ module U3d
 
   class WindowsInstallation < Installation
     def version
+      version = @helper.version
+      return version unless version.nil?
+
       path = "#{root_path}/Editor/Data/"
       package = PlaybackEngineUtils.list_module_configs(path).first
       raise "Couldn't find a module under #{path}" unless package
@@ -354,7 +374,7 @@ module U3d
     end
 
     def build_number
-      @build_number ||= WindowsInstallationHelper.new.build_number(exe_path)
+      @helper.build_number
     end
 
     def default_log_file
@@ -407,6 +427,12 @@ module U3d
 
     def clean_install?
       do_not_move? || !(root_path =~ UNITY_DIR_CHECK).nil?
+    end
+
+    private
+    
+    def helper
+      @helper ||= WindowsInstallationHelper.new(exe_path)
     end
   end
 end


### PR DESCRIPTION
<!--
Thank you for contributing to u3d!
Before you post your pull request, please make sure that you checked the boxes! (put an x in the [ ] without spaces)
If possible, try to name your pull request by prefixing it with <SUBJECT>. For instance, if you're modifying the downloading, you could prefix it with u3d/download:
-->

### Pull Request Checklist

- [x] My pull request has been rebased on master
- [x] I ran `bundle exec rspec` to make sure that my PR didn't break any test
- [x] I ran `bundle exec rubocop` to make sure that my PR is inline with our code style
- [x] I have read the [code of conduct](https://github.com/DragonBox/u3d/blob/master/CODE_OF_CONDUCT.md)

### Pull Request Description

<!-- If this pull request is related to a specific issue, please specify here "Fixes #ISSUE_NO" -->
<!-- Please describe your pull request with as much precision as possible. Write here why you think this change is required, what problem it solves, how it solves it...  -->
<!-- Please describe to what extent you tested your modifications -->

Starting from 2019.2.x, Unity does not use `ivy.xml` anymore. This means that our version retrieval does not work any longer.

This addresses this issue by using the same system we use to retrieve the build number from the .exe, which should prove to be more robust in the long run.

Fixes #354 
Fixes #367 