### PR TITLE
u3d/install: convert Windows paths to ruby paths when treating U3D_EXTRA_PATHS

### DIFF
--- a/lib/u3d/installer.rb
+++ b/lib/u3d/installer.rb
@@ -154,7 +154,7 @@ module U3d
     def find_installations_with_path(default_root_path: '', postfix: [])
       ([default_root_path] | extra_installation_paths).map do |path|
         UI.verbose "Looking for installed Unity version under #{path}"
-        pattern = File.join([path] + postfix)
+        pattern = File.join([path.gsub(File::SEPARATOR, "/")] + postfix)
         Dir.glob(pattern).map { |found_path| yield found_path }
       end.flatten
     end

--- a/lib/u3d/installer.rb
+++ b/lib/u3d/installer.rb
@@ -146,15 +146,18 @@ module U3d
       end
     end
 
+    # extra installation paths are stored in U3D_EXTRA_PATHS environment variable,
+    # following a standard PATH variable format.
+    # Returns an array of ruby style paths
     def extra_installation_paths
       return [] if ENV['U3D_EXTRA_PATHS'].nil?
-      ENV['U3D_EXTRA_PATHS'].strip.split(File::PATH_SEPARATOR)
+      ENV['U3D_EXTRA_PATHS'].strip.split(File::PATH_SEPARATOR).map { |p| File.expand_path p }
     end
 
     def find_installations_with_path(default_root_path: '', postfix: [])
       ([default_root_path] | extra_installation_paths).map do |path|
         UI.verbose "Looking for installed Unity version under #{path}"
-        pattern = File.join([path.gsub(File::SEPARATOR, "/")] + postfix)
+        pattern = File.join([path] + postfix)
         Dir.glob(pattern).map { |found_path| yield found_path }
       end.flatten
     end

--- a/spec/u3d/installer_spec.rb
+++ b/spec/u3d/installer_spec.rb
@@ -90,20 +90,25 @@ describe U3d do
       end
 
       describe ".extra_installation_paths" do
-        it "converts paths to ruby paths" do
-          installer = DummyInstaller.new
-          env_var = if U3dCore::Helper.windows?
-                      "C:\\Program Files\\Unity;D:\\"
-                    else
-                      "/Applications/here:/Applications/else"
-                    end
-          expected_paths = if U3dCore::Helper.windows?
-                             ["C:/Program Files/Unity", "D:/"]
-                           else
-                             ["/Applications/here", "/Applications/else"]
-                           end
-          with_env_values('U3D_EXTRA_PATHS' => env_var) do
-            expect(installer.send(:extra_installation_paths)).to eql(expected_paths)
+        describe "converts paths to ruby paths" do
+          def expect_extra_installation_paths(env_var, expected_paths)
+            installer = DummyInstaller.new
+            with_env_values('U3D_EXTRA_PATHS' => env_var) do
+              expect(installer.send(:extra_installation_paths)).to eql(expected_paths)
+            end
+          end
+          it "works on Windows", if: WINDOWS do
+            expect_extra_installation_paths(
+              "C:\\Program Files\\Unity;D:\\",
+              ["C:/Program Files/Unity", "D:/"]
+            )
+          end
+
+          it "works on Unix", unless: WINDOWS do
+            expect_extra_installation_paths(
+              "/Applications/here:/Applications/else",
+              ["/Applications/here", "/Applications/else"]
+            )
           end
         end
       end

--- a/spec/u3d/installer_spec.rb
+++ b/spec/u3d/installer_spec.rb
@@ -88,6 +88,25 @@ describe U3d do
           expect(installer.installed_sorted_by_versions).to eq(sorted_installed)
         end
       end
+
+      describe ".extra_installation_paths" do
+        it "converts paths to ruby paths" do
+          installer = DummyInstaller.new
+          env_var = if U3dCore::Helper.windows?
+                      "C:\\Program Files\\Unity;D:\\"
+                    else
+                      "/Applications/here:/Applications/else"
+                    end
+          expected_paths = if U3dCore::Helper.windows?
+                             ["C:/Program Files/Unity", "D:/"]
+                           else
+                             ["/Applications/here", "/Applications/else"]
+                           end
+          with_env_values('U3D_EXTRA_PATHS' => env_var) do
+            expect(installer.send(:extra_installation_paths)).to eql(expected_paths)
+          end
+        end
+      end
     end
 
     describe U3d::MacInstaller, unless: WINDOWS do

--- a/spec/u3d_core/helper_spec.rb
+++ b/spec/u3d_core/helper_spec.rb
@@ -34,7 +34,7 @@ describe U3dCore do
         if U3dCore::Helper.windows?
           path = File.expand_path "C:\\Program Files\\"
           puts path
-          `dir C:\\`
+          puts `dir C:\\`
           puts File.exist? path
         else
           puts "Not the platform you are looking for"

--- a/spec/u3d_core/helper_spec.rb
+++ b/spec/u3d_core/helper_spec.rb
@@ -29,17 +29,5 @@ describe U3dCore do
         expect(U3dCore::Helper.windows_path('/path/to/file')).to eql "\\path\\to\\file"
       end
     end
-    describe 'experiments' do
-      it 'expands paths...' do
-        if U3dCore::Helper.windows?
-          path = File.expand_path "C:\\Program Files\\"
-          puts path
-          puts `dir C:\\`
-          puts File.exist? path
-        else
-          puts "Not the platform you are looking for"
-        end
-      end
-    end
   end
 end

--- a/spec/u3d_core/helper_spec.rb
+++ b/spec/u3d_core/helper_spec.rb
@@ -1,0 +1,33 @@
+## --- BEGIN LICENSE BLOCK ---
+# Copyright (c) 2019-present WeWantToKnow AS
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+## --- END LICENSE BLOCK ---
+
+require 'u3d/utils'
+
+describe U3dCore do
+  describe U3d::Helper do
+    describe '.windows_path' do
+      it 'converts paths' do
+        expect(U3dCore::Helper.windows_path('/path/to/file')).to eql "\\path\\to\\file"
+      end
+    end
+  end
+end

--- a/spec/u3d_core/helper_spec.rb
+++ b/spec/u3d_core/helper_spec.rb
@@ -29,5 +29,17 @@ describe U3dCore do
         expect(U3dCore::Helper.windows_path('/path/to/file')).to eql "\\path\\to\\file"
       end
     end
+    describe 'experiments' do
+      it 'expands paths...' do
+        if U3dCore::Helper.windows?
+          path = File.expand_path "C:\\Program Files\\"
+          puts path
+          `dir C:\\`
+          puts File.exist? path
+        else
+          puts "Not the platform you are looking for"
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
### Pull Request Checklist

- [x] My pull request has been rebased on master
- [x] I ran `bundle exec rspec` to make sure that my PR didn't break any test
- [x] I ran `bundle exec rubocop` to make sure that my PR is inline with our code style
- [x] I have read the [code of conduct](https://github.com/DragonBox/u3d/blob/master/CODE_OF_CONDUCT.md)

### Pull Request Description

The documentation states that U3D_EXTRA_PATHS are windows style.

Fixes #383 