### PR TITLE
Detect 2019 modules and allow to install 2019, skipping dmg install for now

### DIFF
--- a/lib/u3d.rb
+++ b/lib/u3d.rb
@@ -51,7 +51,8 @@ module U3d
 
   def self.const_missing(const_name)
     deprecated = {
-      PlaybackEngineUtils: IvyPlaybackEngineUtils
+      PlaybackEngineUtils: IvyPlaybackEngineUtils,
+      INIParser: INIModulesParser
     }
     super unless deprecated.keys.include? const_name
     replacement = deprecated[const_name]

--- a/lib/u3d.rb
+++ b/lib/u3d.rb
@@ -48,4 +48,14 @@ require 'u3d/unity_versions'
 module U3d
   Helper = U3dCore::Helper
   UI = U3dCore::UI
+
+  def self.const_missing(const_name)
+    deprecated = {
+      PlaybackEngineUtils: IvyPlaybackEngineUtils
+    }
+    super unless deprecated.keys.include? const_name
+    replacement = deprecated[const_name]
+    UI.deprecated "DEPRECATION WARNING: the class U3d::#{const_name} is deprecated. Use #{replacement} instead."
+    replacement
+  end
 end

--- a/lib/u3d/commands.rb
+++ b/lib/u3d/commands.rb
@@ -342,9 +342,8 @@ module U3d
           UI.verbose "Version #{version} of Unity is not installed yet"
         else
           UI.verbose "Unity #{version} is installed at #{unity.root_path}"
-          return unity
         end
-        nil
+        unity
       end
 
       # rubocop:disable Metrics/BlockNesting

--- a/lib/u3d/downloader.rb
+++ b/lib/u3d/downloader.rb
@@ -33,7 +33,7 @@ module U3d
     # Regex to get the name of a localization asset
     UNITY_LANGUAGE_FILE_REGEX = %r{\/\d+/[0-9\.]+\/([\w-]+)$}
     # Regex to get the name of a package out of its file name
-    UNITY_MODULE_FILE_REGEX = %r{\/([\w\-_\.\+]+\.(?:pkg|exe|zip|sh|deb|msi|xz))[^\/]*$}
+    UNITY_MODULE_FILE_REGEX = %r{\/([\w\-_\.\+]+\.(?:pkg|dmg|exe|zip|sh|deb|msi|xz))[^\/]*$}
 
     class << self
       def download_directory

--- a/lib/u3d/ini_modules_parser.rb
+++ b/lib/u3d/ini_modules_parser.rb
@@ -25,30 +25,6 @@ require 'u3d/utils'
 require 'u3d_core/helper'
 
 module U3d
-  # Backwards compatibility
-  module INIParser
-    class << self
-      def method_missing(method_name, *arguments, &block)
-        UI.deprecated 'INIParser is obsolete, Use INIModulesParser instead'
-        if INIModulesParser.respond_to?(method_name)
-          INIModulesParser.send(method_name, *arguments, &block)
-        else
-          super
-        end
-      end
-
-      def respond_to?(method_name, include_private = false)
-        UI.deprecated 'INIParser is obsolete, Use INIModulesParser instead'
-        INIModulesParser.respond_to?(method_name, include_private)
-      end
-
-      def respond_to_missing?(method_name, include_private = false)
-        UI.deprecated 'INIParser is obsolete, Use INIModulesParser instead'
-        INIModulesParser.respond_to_missing?(method_name, include_private)
-      end
-    end
-  end
-
   # Load and parse INI files
   module INIModulesParser
     #####################################################

--- a/lib/u3d/installation.rb
+++ b/lib/u3d/installation.rb
@@ -127,13 +127,9 @@ module U3d
     end
   end
 
-  # FIXME: deprecated
-  class PlaybackEngineUtils < IvyPlaybackEngineUtils
-  end
-
   class ModulePlaybackEngineUtils
     def self.list_module_configs(playbackengine_parent_path)
-      # FIXME: this is Mac specific
+      # this should work on all platforms, non existing paths being ignored...
       Dir.glob("#{playbackengine_parent_path}/PlaybackEngines/*/modules.asset") |
         Dir.glob("#{playbackengine_parent_path}/Unity.app/Contents/PlaybackEngines/*/modules.asset")
     end

--- a/lib/u3d/installation.rb
+++ b/lib/u3d/installation.rb
@@ -105,7 +105,7 @@ module U3d
     end
   end
 
-  class PlaybackEngineUtils
+  class IvyPlaybackEngineUtils
     def self.list_module_configs(playbackengine_parent_path)
       Dir.glob("#{playbackengine_parent_path}/PlaybackEngines/*/ivy.xml")
     end
@@ -126,6 +126,22 @@ module U3d
       node_value(config_path, 'ivy-module/info/@e:unityVersion')
     end
   end
+
+  # FIXME deprecated
+  class PlaybackEngineUtils < IvyPlaybackEngineUtils
+  end
+
+  class ModulePlaybackEngineUtils
+    def self.list_module_configs(playbackengine_parent_path)
+      # FIXME this is Mac specific
+      Dir.glob("#{playbackengine_parent_path}/PlaybackEngines/*/modules.asset") | 
+        Dir.glob("#{playbackengine_parent_path}/Unity.app/Contents/PlaybackEngines/*/modules.asset")
+    end
+
+    def self.module_name(config_path)
+      File.basename(File.dirname(config_path)).gsub("Support", "")
+    end
+  end  
 
   class MacInstallation < Installation
     require 'plist'
@@ -154,9 +170,13 @@ module U3d
 
     def packages
       pack = []
-      PlaybackEngineUtils.list_module_configs(root_path).each do |mpath|
-        pack << PlaybackEngineUtils.module_name(mpath)
+      IvyPlaybackEngineUtils.list_module_configs(root_path).each do |mpath|
+        pack << IvyPlaybackEngineUtils.module_name(mpath)
       end
+      ModulePlaybackEngineUtils.list_module_configs(root_path).each do |mpath|
+        pack << ModulePlaybackEngineUtils.module_name(mpath)
+      end
+
       NOT_PLAYBACKENGINE_PACKAGES.each do |module_name|
         pack << module_name unless Dir[module_name_pattern(module_name)].empty?
       end
@@ -238,9 +258,9 @@ module U3d
     def version
       # I don't find an easy way to extract the version on Linux
       path = "#{root_path}/Editor/Data/"
-      package = PlaybackEngineUtils.list_module_configs(path).first
+      package = IvyPlaybackEngineUtils.list_module_configs(path).first
       raise "Couldn't find a module under #{path}" unless package
-      version = PlaybackEngineUtils.unity_version(package)
+      version = IvyPlaybackEngineUtils.unity_version(package) # FIXME
       if (m = version.match(/^(.*)x(.*)Linux$/))
         version = "#{m[1]}#{m[2]}"
       end
@@ -267,8 +287,11 @@ module U3d
     def packages
       path = "#{root_path}/Editor/Data/"
       pack = []
-      PlaybackEngineUtils.list_module_configs(path).each do |mpath|
-        pack << PlaybackEngineUtils.module_name(mpath)
+      IvyPlaybackEngineUtils.list_module_configs(path).each do |mpath|
+        pack << IvyPlaybackEngineUtils.module_name(mpath)
+      end
+      ModulePlaybackEngineUtils.list_module_configs(root_path).each do |mpath|
+        pack << ModulePlaybackEngineUtils.module_name(mpath)
       end
       NOT_PLAYBACKENGINE_PACKAGES.each do |module_name|
         pack << module_name unless Dir[module_name_pattern(module_name)].empty?
@@ -368,9 +391,9 @@ module U3d
       return version unless version.nil?
 
       path = "#{root_path}/Editor/Data/"
-      package = PlaybackEngineUtils.list_module_configs(path).first
+      package = IvyPlaybackEngineUtils.list_module_configs(path).first
       raise "Couldn't find a module under #{path}" unless package
-      PlaybackEngineUtils.unity_version(package)
+      IvyPlaybackEngineUtils.unity_version(package)
     end
 
     def build_number
@@ -403,8 +426,11 @@ module U3d
     def packages
       path = "#{root_path}/Editor/Data/"
       pack = []
-      PlaybackEngineUtils.list_module_configs(path).each do |mpath|
-        pack << PlaybackEngineUtils.module_name(mpath)
+      IvyPlaybackEngineUtils.list_module_configs(path).each do |mpath|
+        pack << IvyPlaybackEngineUtils.module_name(mpath)
+      end
+      ModulePlaybackEngineUtils.list_module_configs(root_path).each do |mpath|
+        pack << ModulePlaybackEngineUtils.module_name(mpath)
       end
       NOT_PLAYBACKENGINE_PACKAGES.each do |module_name|
         pack << module_name unless Dir[module_name_pattern(module_name)].empty?

--- a/lib/u3d/installer.rb
+++ b/lib/u3d/installer.rb
@@ -191,12 +191,14 @@ module U3d
     def install(file_path, version, installation_path: nil, info: nil)
       # rubocop:enable UnusedMethodArgument
       extension = File.extname(file_path)
-      raise "Installation of #{extension} files is not supported on Mac" unless %w[.zip .po .pkg].include? extension
+      raise "Installation of #{extension} files is not supported on Mac" unless %w[.zip .po .pkg .dmg].include? extension
       path = installation_path || DEFAULT_MAC_INSTALL
       if extension == '.po'
         install_po(file_path, version, info: info)
       elsif extension == '.zip'
         install_zip(file_path, version, info: info)
+      elsif extension == '.dmg'
+        UI.important "Skipping installation of #{file_path} for now"
       else
         install_pkg(file_path, version: version, target_path: path)
       end


### PR DESCRIPTION
Definitively WIP with Windows not supported at all.

The approach is to use the `modules.asset` files to detect Playback Engines. @niezbop any better idea on how to support this?

I will also need some help to test this on Windows at some point. Maybe @BastianBlokland would like to test it on Linux?