### PR TITLE
Create Github releases. Required for #390. [Fixes #389]

### DIFF
--- a/DEVELOPMENT_PROCESS.md
+++ b/DEVELOPMENT_PROCESS.md
@@ -9,6 +9,7 @@
 * make a release
 
 `rake release`
+`rake create_missing_github_releases`
 
 = release of the fastlane plugin
 


### PR DESCRIPTION
I used it to create the releases: https://github.com/DragonBox/u3d/releases

Note that I could make it even better by properly  using it in the rake release task, but didn't care right now.