### PR TITLE
Fixing error when installing Unity 2020 version in Linux

### DIFF
--- a/lib/u3d/installation.rb
+++ b/lib/u3d/installation.rb
@@ -27,6 +27,7 @@ require 'fileutils'
 module U3d
   UNITY_DIR_CHECK = /Unity_\d+\.\d+\.\d+[a-z]\d+/
   UNITY_DIR_CHECK_LINUX = /unity-editor-\d+\.\d+\.\d+[a-z]\d+\z/
+  #Linux unity_builtin_extra seek position for version
   UNITY_VERSION_LINUX_POS_LE_2019 = 20
   UNITY_VERSION_LINUX_POS_GT_2019 = 48
   U3D_DO_NOT_MOVE = ".u3d_do_not_move".freeze

--- a/lib/u3d/installation.rb
+++ b/lib/u3d/installation.rb
@@ -27,6 +27,8 @@ require 'fileutils'
 module U3d
   UNITY_DIR_CHECK = /Unity_\d+\.\d+\.\d+[a-z]\d+/
   UNITY_DIR_CHECK_LINUX = /unity-editor-\d+\.\d+\.\d+[a-z]\d+\z/
+  UNITY_VERSION_LINUX_POS_LE_2019 = 20
+  UNITY_VERSION_LINUX_POS_GT_2019 = 48
   U3D_DO_NOT_MOVE = ".u3d_do_not_move".freeze
 
   class Installation
@@ -142,7 +144,15 @@ module U3d
   class InstallationUtils
     def self.read_version_from_unity_builtin_extra(file)
       File.open(file, "rb") do |f|
-        f.seek(20)
+        # Check if it is version lower or equal to 2019
+        seek_pos = UNITY_VERSION_LINUX_POS_LE_2019
+        f.seek(seek_pos)
+        z = f.read(1)
+        if z == "\x00"
+          # Version is greater than 2019
+          seek_pos = UNITY_VERSION_LINUX_POS_GT_2019
+        end
+        f.seek(seek_pos)
         s = ""
         while (c = f.read(1))
           break if c == "\x00"

--- a/lib/u3d/installation.rb
+++ b/lib/u3d/installation.rb
@@ -27,7 +27,7 @@ require 'fileutils'
 module U3d
   UNITY_DIR_CHECK = /Unity_\d+\.\d+\.\d+[a-z]\d+/
   UNITY_DIR_CHECK_LINUX = /unity-editor-\d+\.\d+\.\d+[a-z]\d+\z/
-  #Linux unity_builtin_extra seek position for version
+  # Linux unity_builtin_extra seek position for version
   UNITY_VERSION_LINUX_POS_LE_2019 = 20
   UNITY_VERSION_LINUX_POS_GT_2019 = 48
   U3D_DO_NOT_MOVE = ".u3d_do_not_move".freeze


### PR DESCRIPTION
<!--
Thank you for contributing to u3d!
Before you post your pull request, please make sure that you checked the boxes! (put an x in the [ ] without spaces)
If possible, try to name your pull request by prefixing it with <SUBJECT>. For instance, if you're modifying the downloading, you could prefix it with u3d/download:
-->

### Pull Request Checklist

- [x] My pull request has been rebased on master
- [x] I ran `bundle exec rspec` to make sure that my PR didn't break any test
- [x] I ran `bundle exec rubocop` to make sure that my PR is inline with our code style
- [x] I have read the [code of conduct](https://github.com/DragonBox/u3d/blob/master/CODE_OF_CONDUCT.md)

### Pull Request Description

<!-- If this pull request is related to a specific issue, please specify here "Fixes #407 " -->
<!-- Please describe your pull request with as much precision as possible. Write here why you think this change is required, what problem it solves, how it solves it...  -->
<!-- Please describe to what extent you tested your modifications -->

[DESCRIBE YOUR PULL REQUEST HERE]
This pull request solves the error when installing in Linux a Unity version 2020. It seems that untill Unity 2019, the unity_builtin_extra file has the string version coded at byte position 20. In 2020 the string version is coded from byte position 48. It has been coded a check for trying reading what it is expected in 2019 and if it is "\x00" set the seek position for 2020. 