### PR TITLE
Fix installation of modules for non latest releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
           command: |
             echo 'export BUNDLER_VERSION=$(cat Gemfile.lock | tail -1 | tr -d " ")' >> $BASH_ENV
             source $BASH_ENV
-            gem install bundler
+            gem install bundler -v "$BUNDLER_VERSION"
             bundle config set path '.bundle'
 
       - run:

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ gems/
 doc/
 LOCAL/
 .DS_Store
+.bundle/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,7 +117,7 @@ GEM
     tins (1.15.0)
     tzinfo (1.2.3)
       thread_safe (~> 0.1)
-    unicode-display_width (1.3.0)
+    unicode-display_width (1.8.0)
 
 PLATFORMS
   ruby
@@ -136,4 +136,4 @@ DEPENDENCIES
   u3d!
 
 BUNDLED WITH
-   2.1.4
+   2.2.30

--- a/lib/u3d/hub_modules_parser.rb
+++ b/lib/u3d/hub_modules_parser.rb
@@ -40,7 +40,24 @@ module U3d
 
         unless File.file?(path) && File.size(path) > 0
           UI.verbose "No modules registered for UnityHub for version #{version}"
-          return []
+          # cached_versions.keys.map{|s| UnityVersionNumber.new(s)}
+          # searching for closest version
+          files = Dir.glob("#{default_modules_path}/*-#{os}-modules.json")
+
+          vn = UnityVersionNumber.new(version)
+
+          versions_and_paths = files.map do |p|
+            v = File.basename(p).split('-')[0]
+            [UnityVersionNumber.new(v), p]
+          end
+          # filtered by version major.minor.patch (same major & minor and patch higher or equal)
+          versions_and_paths = versions_and_paths.select { |a| a[0].parts[0] == vn.parts[0] && a[0].parts[1] == vn.parts[1] && a[0].parts[2] >= vn.parts[2] }
+
+          if versions_and_paths.empty?
+            UI.info "No closest version from UnityHub found for version #{version}"
+            return []
+          end
+          path = versions_and_paths.first[1]
         end
 
         return JSON.parse(File.read(path))

--- a/lib/u3d/hub_modules_parser.rb
+++ b/lib/u3d/hub_modules_parser.rb
@@ -33,14 +33,14 @@ module U3d
       def load_modules(version, os: U3dCore::Helper.operating_system, offline: false)
         path = modules_path(version, os)
 
+        # force download if no hub file present
         unless File.file?(path) && File.size(path) > 0
-          return [] if offline # Should not raise, not all versions have hub modules
-          versions = download_modules(os: os)
+          download_modules(os: os) unless offline
+        end
 
-          unless versions.include? version
-            UI.verbose "No modules registered for UnityHub for version #{version}"
-            return []
-          end
+        unless File.file?(path) && File.size(path) > 0
+          UI.verbose "No modules registered for UnityHub for version #{version}"
+          return []
         end
 
         return JSON.parse(File.read(path))


### PR DESCRIPTION
### Pull Request Description

We know that non-latest releases don't have their optional modules available. This is an attempt to fix it.

Looks like it works.
```
$ bundle console
 U3d::Commands.list_available(options: {unity_version: '2020.3.10f1', packages: 1})
Version 2020.3.10f1: https://download.unity3d.com/download_unity/297d780c91bc/
Packages:
 - Unity
 - Mono
 - Visualstudio
 - Android
 - Ios
 - Appletv
 - Linux-il2cpp
 - Linux-mono
 - Mac-il2cpp
 - Webgl
 - Windows-mono
 - Lumin
 - Documentation
 - Language-ja
 - Language-ko
 - Language-zh-hans
 - Language-zh-hant
 - Android-sdk-ndk-tools
 - Android-sdk-platform-tools
 - Android-sdk-build-tools
 - Android-sdk-platforms
 - Android-ndk
 - Android-open-jdk
 => ["2020.3.10f1"] 

U3d::Commands.install(args: ["2020.3.26f1"], options:{download: true, all: true, install:true})
/Users/lacostej/Code/OSS/u3d/.bundle/ruby/2.7.0/gems/json-2.1.0/lib/json/common.rb:156: warning: Using the last argument as keyword parameters is deprecated
/Users/lacostej/Code/OSS/u3d/.bundle/ruby/2.7.0/gems/json-2.1.0/lib/json/common.rb:156: warning: Using the last argument as keyword parameters is deprecated
/Users/lacostej/Code/OSS/u3d/.bundle/ruby/2.7.0/gems/json-2.1.0/lib/json/common.rb:156: warning: Using the last argument as keyword parameters is deprecated
Unity 2020.3.26f1 is already installed
Mono for Visual Studio for Mac depends on VisualStudio, but it's neither installed nor being installed.
Root privileges are required
Password for lacostej:
*********
No credentials storage available
Password for lacostej:
*********
No credentials storage available
Password for lacostej:
*********
No credentials storage available
Unity 2020.3.26f1 is already downloaded
Android Build Support is already downloaded
Android NDK is already downloaded
OpenJDK is already downloaded
Android SDK & NDK Tools is already downloaded
Android SDK Build Tools is already downloaded
Android SDK Platform Tools is already downloaded
Android SDK Platforms 29 is already downloaded
Android SDK Platforms 30 is already downloaded
tvOS Build Support is already downloaded
Documentation is already downloaded
iOS Build Support is already downloaded
日本語 is already downloaded
한국어 is already downloaded
简体中文 is already downloaded
繁體中文 is already downloaded
Linux Build Support (IL2CPP) is already downloaded
Linux Build Support (Mono) is already downloaded
Lumin OS (Magic Leap) Build Support is already downloaded
Mac Build Support (IL2CPP) is already downloaded
Mono for Visual Studio for Mac is already downloaded
Visual Studio for Mac is already downloaded
WebGL Build Support is already downloaded
Windows Build Support (Mono) is already downloaded
--------------------------------------------
--- Installing Unity 2020.3.26f1 (unity) ---
--------------------------------------------
Installing with /Users/lacostej/Downloads/Unity_Packages/2020.3.26f1/Unity.pkg
$ installer -pkg /Users/lacostej/Downloads/Unity_Packages/2020.3.26f1/Unity.pkg -target /
Failed to install pkg at /Users/lacostej/Downloads/Unity_Packages/2020.3.26f1/Unity.pkg: Exit status: 1
--------------------------------------------------
--- Installing Android Build Support (android) ---
--------------------------------------------------
Installing with /Users/lacostej/Downloads/Unity_Packages/2020.3.26f1/UnitySetup-Android-Support-for-Editor-2020.3.26f1.pkg
$ installer -pkg /Users/lacostej/Downloads/Unity_Packages/2020.3.26f1/UnitySetup-Android-Support-for-Editor-2020.3.26f1.pkg -target /
Successfully installed package from /Users/lacostej/Downloads/Unity_Packages/2020.3.26f1/UnitySetup-Android-Support-for-Editor-2020.3.26f1.pkg
--------------------------------------------
--- Installing Android NDK (android-ndk) ---
--------------------------------------------
Installing with /Users/lacostej/Downloads/Unity_Packages/2020.3.26f1/android-ndk-r19-darwin-x86_64.zip
$ stat -f "%Su,%A" /Applications/Unity_2020.3.26f1/PlaybackEngines/AndroidPlayer
$ whoami
$ chown lacostej: /Applications/Unity_2020.3.26f1/PlaybackEngines/AndroidPlayer
$ chmod u+w /Applications/Unity_2020.3.26f1/PlaybackEngines/AndroidPlayer
$ chown root: /Applications/Unity_2020.3.26f1/PlaybackEngines/AndroidPlayer
$ chmod 755 /Applications/Unity_2020.3.26f1/PlaybackEngines/AndroidPlayer
Successfully unizpped android-ndk-r19-darwin-x86_64.zip at /Applications/Unity_2020.3.26f1/PlaybackEngines/AndroidPlayer/NDK
---------------------------------------------
--- Installing OpenJDK (android-open-jdk) ---
---------------------------------------------
[...]
```