### PR TITLE
Run rspec within bundle exec

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -184,7 +184,7 @@ task bump: 'ensure_git_clean' do
   UI.user_error! "Bump version stopped by user" unless UI.confirm("Next version will be #{nextversion}. Confirm?")
   U3dCode.version = nextversion
   GithubChangelogGenerator.future_release = nextversion
-  sh 'rspec'
+  sh 'bundle exec rspec'
   sh 'git add .github_changelog_generator lib/u3d/version.rb Gemfile.lock'
   sh "git commit -m 'Bump version to #{nextversion}'"
   sh 'git push'


### PR DESCRIPTION
### Pull Request Description

rspec fails if you have conflicting versions of coveralls and simplecov

```
acostej@MacBook-Pro ~/Code/OSS/u3d (master) rspec

An error occurred while loading spec_helper. - Did you mean?
                    rspec ./spec/spec_helper.rb

Failure/Error: require 'coveralls'

Gem::ConflictError:
  Unable to activate coveralls-0.8.23, because simplecov-0.17.1 conflicts with simplecov (~> 0.16.1)
# ./spec/spec_helper.rb:26:in `<top (required)>'
# ------------------
# --- Caused by: ---
# LoadError:
#   cannot load such file -- coveralls
#   ./spec/spec_helper.rb:26:in `<top (required)>'
No examples found.
No examples found.


Finished in 0.00002 seconds (files took 0.18473 seconds to load)
0 examples, 0 failures, 1 error occurred outside of examples

Finished in 0.00002 seconds (files took 0.18473 seconds to load)
0 examples, 0 failures, 1 error occurred outside of examples

```