### PR TITLE
fix: replace usage of nonexistent UI.info method

### DIFF
--- a/lib/u3d/hub_modules_parser.rb
+++ b/lib/u3d/hub_modules_parser.rb
@@ -54,7 +54,7 @@ module U3d
           versions_and_paths = versions_and_paths.select { |a| a[0].parts[0] == vn.parts[0] && a[0].parts[1] == vn.parts[1] && a[0].parts[2] >= vn.parts[2] }
 
           if versions_and_paths.empty?
-            UI.info "No closest version from UnityHub found for version #{version}"
+            UI.message "No closest version from UnityHub found for version #{version}"
             return []
           end
           path = versions_and_paths.first[1]


### PR DESCRIPTION
<!--
Thank you for contributing to u3d!
Before you post your pull request, please make sure that you checked the boxes! (put an x in the [ ] without spaces)
If possible, try to name your pull request by prefixing it with <SUBJECT>. For instance, if you're modifying the downloading, you could prefix it with u3d/download:
-->

### Pull Request Checklist

- [x] My pull request has been rebased on master
- [x] I ran `bundle exec rspec` to make sure that my PR didn't break any test
- [x] I ran `bundle exec rubocop` to make sure that my PR is inline with our code style
- [x] I have read the [code of conduct](https://github.com/DragonBox/u3d/blob/master/CODE_OF_CONDUCT.md)

### Pull Request Description

<!-- If this pull request is related to a specific issue, please specify here "Fixes #ISSUE_NO" -->
<!-- Please describe your pull request with as much precision as possible. Write here why you think this change is required, what problem it solves, how it solves it...  -->
<!-- Please describe to what extent you tested your modifications -->

#416 seems to have introduced a bug where an attempt is made to call a method named `info` on the UI interface, but this method doesn't exist. This PR simply changes the call to `UI.message` instead.

Fixes #430