### PR TITLE
[Fix] U3d::Utils: replace Ruby agent with another one to bypass 403 from Unity

### DIFF
--- a/lib/u3d/utils.rb
+++ b/lib/u3d/utils.rb
@@ -34,6 +34,9 @@ module U3d
     # Regex to capture each part of a version string (0.0.0x0)
     CSIDL_LOCAL_APPDATA = 0x001c
     UNITY_VERSION_REGEX = /(\d+)(?:\.(\d+)(?:\.(\d+))?)?(?:(\w)(?:(\d+))?)?/.freeze
+    MOZILLA_AGENT_HEADER = {
+      'User-Agent' => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:106.0) Gecko/20100101 Firefox/106.0'
+    }.freeze
 
     class << self
       def final_url(url, redirect_limit: 10)
@@ -55,6 +58,9 @@ module U3d
 
       def follow_redirects(url, redirect_limit: 10, http_method: :get, request_headers: {}, &block)
         raise 'Too many redirections' if redirect_limit.zero?
+
+        # Unity blocks the default Ruby agent, use another one
+        request_headers = MOZILLA_AGENT_HEADER.merge(request_headers)
 
         response = nil
         request = nil


### PR DESCRIPTION
…

<!--
Thank you for contributing to u3d!
Before you post your pull request, please make sure that you checked the boxes! (put an x in the [ ] without spaces)
If possible, try to name your pull request by prefixing it with <SUBJECT>. For instance, if you're modifying the downloading, you could prefix it with u3d/download:
-->

### Pull Request Checklist

- [x] My pull request has been rebased on master
- [x] I ran `bundle exec rspec` to make sure that my PR didn't break any test
- [x] I ran `bundle exec rubocop` to make sure that my PR is inline with our code style
- [x] I have read the [code of conduct](https://github.com/DragonBox/u3d/blob/master/CODE_OF_CONDUCT.md)

### Pull Request Description

Fixes #433 

Unity has started blocking the default Ruby agent, which leads u3d to face 403 Forbidden when making requests to their system. This makes it so that our ongoing requests use Mozilla's browser agent to bypass this issue.