### PR TITLE
Update package dependencies to resolve circular dependency issue

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ PATH
       plist (>= 3.1.0, < 4.0.0)
       rexml
       rubyzip (>= 1.0.0)
-      security (= 0.1.3)
+      security (= 0.1.5)
 
 GEM
   remote: https://rubygems.org/
@@ -160,7 +160,7 @@ GEM
     sawyer (0.8.2)
       addressable (>= 2.3.5)
       faraday (> 0.8, < 2.0)
-    security (0.1.3)
+    security (0.1.5)
     simplecov (0.16.1)
       docile (~> 1.1)
       json (>= 1.8, < 3)

--- a/examples/Example1/Gemfile.lock
+++ b/examples/Example1/Gemfile.lock
@@ -16,7 +16,7 @@ PATH
       plist (>= 3.1.0, < 4.0.0)
       rexml
       rubyzip (>= 1.0.0)
-      security (= 0.1.3)
+      security (= 0.1.5)
 
 GEM
   remote: https://rubygems.org/
@@ -75,7 +75,7 @@ GEM
       plist (>= 3.1.0, < 4.0.0)
       public_suffix (~> 2.0.0)
       rubyzip (>= 1.3.0, < 2.0.0)
-      security (= 0.1.3)
+      security (= 0.1.5)
       simctl (~> 1.6.3)
       slack-notifier (>= 2.0.0, < 3.0.0)
       terminal-notifier (>= 2.0.0, < 3.0.0)

--- a/examples/Example2/Gemfile.lock
+++ b/examples/Example2/Gemfile.lock
@@ -16,7 +16,7 @@ PATH
       plist (>= 3.1.0, < 4.0.0)
       rexml
       rubyzip (>= 1.0.0)
-      security (= 0.1.3)
+      security (= 0.1.5)
 
 GEM
   remote: https://rubygems.org/
@@ -75,7 +75,7 @@ GEM
       plist (>= 3.1.0, < 4.0.0)
       public_suffix (~> 2.0.0)
       rubyzip (>= 1.3.0, < 2.0.0)
-      security (= 0.1.3)
+      security (= 0.1.5)
       simctl (~> 1.6.3)
       slack-notifier (>= 2.0.0, < 3.0.0)
       terminal-notifier (>= 2.0.0, < 3.0.0)
@@ -142,7 +142,7 @@ GEM
     rexml (3.2.5)
     rouge (2.0.7)
     rubyzip (1.3.0)
-    security (0.1.3)
+    security (0.1.5)
     signet (0.12.0)
       addressable (~> 2.3)
       faraday (~> 0.9)

--- a/u3d.gemspec
+++ b/u3d.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'plist', '>= 3.1.0', '< 4.0.0' # Generate the Xcode config plist file
   spec.add_dependency "rexml" # rexml was unbundled from the stdlib in ruby 3
   spec.add_dependency 'rubyzip', '>= 1.0.0' # Installation of .zip files
-  spec.add_dependency 'security', '= 0.1.3' # macOS Keychain manager, a dead project, no updates expected
+  spec.add_dependency 'security', '= 0.1.5' # macOS Keychain manager, a dead project, no updates expected
   # Development only
   spec.add_development_dependency "activesupport", ">= 5.2.4.3" # force secure transitive dep
   spec.add_development_dependency "addressable", ">= 2.8.0" # force secure transitive dep


### PR DESCRIPTION
### Pull Request Checklist

- [x] My pull request has been rebased on master
- [ ] I ran `bundle exec rspec` to make sure that my PR didn't break any test
- [ ] I ran `bundle exec rubocop` to make sure that my PR is inline with our code style
- [x] I have read the [code of conduct](https://github.com/DragonBox/u3d/blob/master/CODE_OF_CONDUCT.md)

### Pull Request Description
This PR updates the version numbers in the gemspec to resolve a circular dependency problem that prevented upgrading Fastlane (to version 2.220.0). Specifically, updated security from 0.1.3 to 0.1.5 to align with Fastlane's newer version requirements.

This change has been tested and ensures that Fastlane can now be successfully upgraded without conflicts.

Contributed on behalf of [Agens](https://agens.no).