### PR TITLE
Gemspec: bump dependency to security to 0.1.5

### DIFF
--- a/u3d.gemspec
+++ b/u3d.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'plist', '>= 3.1.0', '< 4.0.0' # Generate the Xcode config plist file
   spec.add_dependency "rexml" # rexml was unbundled from the stdlib in ruby 3
   spec.add_dependency 'rubyzip', '>= 1.0.0' # Installation of .zip files
-  spec.add_dependency 'security', '= 0.1.3' # macOS Keychain manager, a dead project, no updates expected
+  spec.add_dependency 'security', '= 0.1.5' # macOS Keychain manager, a dead project, no updates expected
   # Development only
   spec.add_development_dependency "activesupport", ">= 5.2.4.3" # force secure transitive dep
   spec.add_development_dependency "addressable", ">= 2.8.0" # force secure transitive dep


### PR DESCRIPTION
In line with [fastlane](https://github.com/fastlane/fastlane/blob/master/fastlane.gemspec#L103) dependency on this gem, this bumps the dependency to remain compatible with them!