### PR TITLE
Fix u3d console not working on Ruby 3.3+

### DIFF
--- a/lib/u3d/commands.rb
+++ b/lib/u3d/commands.rb
@@ -69,12 +69,12 @@ module U3d
         require 'irb'
         ARGV.clear
         IRB.setup(nil)
-        @irb = IRB::Irb.new(nil)
+        workspace = IRB::WorkSpace.new(binding)
+        @irb = IRB::Irb.new(workspace)
         IRB.conf[:MAIN_CONTEXT] = @irb.context
         IRB.conf[:PROMPT][:U3D] = IRB.conf[:PROMPT][:SIMPLE].dup
         IRB.conf[:PROMPT][:U3D][:RETURN] = "%s\n"
         @irb.context.prompt_mode = :U3D
-        @irb.context.workspace = IRB::WorkSpace.new(binding)
         trap 'INT' do
           @irb.signal_handle
         end

--- a/spec/u3d/console_spec.rb
+++ b/spec/u3d/console_spec.rb
@@ -1,0 +1,48 @@
+require 'irb'
+require 'u3d/commands'
+
+describe U3d::Commands do
+  describe '.console' do
+    let(:irb_instance) { instance_double(IRB::Irb) }
+    let(:irb_context) { instance_double(IRB::Context) }
+
+    before do
+      allow(IRB).to receive(:setup)
+      allow(IRB::Irb).to receive(:new).and_return(irb_instance)
+      allow(irb_instance).to receive(:context).and_return(irb_context)
+      allow(irb_context).to receive(:prompt_mode=)
+      allow(irb_instance).to receive(:signal_handle)
+      allow(irb_instance).to receive(:eval_input)
+
+      IRB.conf[:PROMPT] ||= {}
+      IRB.conf[:PROMPT][:SIMPLE] ||= {}
+    end
+
+    it "sets up IRB with a workspace passed to the constructor" do
+      expect(IRB::WorkSpace).to receive(:new).with(an_instance_of(Binding)).and_call_original
+      expect(IRB::Irb).to receive(:new).with(an_instance_of(IRB::WorkSpace)).and_return(irb_instance)
+
+      U3d::Commands.console
+    end
+
+    it "configures the U3D prompt mode" do
+      expect(irb_context).to receive(:prompt_mode=).with(:U3D)
+
+      U3d::Commands.console
+
+      expect(IRB.conf[:PROMPT][:U3D][:RETURN]).to eq("%s\n")
+    end
+
+    it "displays the welcome message" do
+      expect(U3d::UI).to receive(:message).with('Welcome to u3d interactive!')
+
+      U3d::Commands.console
+    end
+
+    it "starts the IRB eval loop" do
+      expect(irb_instance).to receive(:eval_input)
+
+      U3d::Commands.console
+    end
+  end
+end

--- a/spec/u3d/console_spec.rb
+++ b/spec/u3d/console_spec.rb
@@ -1,3 +1,27 @@
+# frozen_string_literal: true
+
+## --- BEGIN LICENSE BLOCK ---
+# Copyright (c) 2016-present WeWantToKnow AS
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+## --- END LICENSE BLOCK ---
+
 require 'irb'
 require 'u3d/commands'
 


### PR DESCRIPTION
<!--
Thank you for contributing to u3d!
Before you post your pull request, please make sure that you checked the boxes! (put an x in the [ ] without spaces)
If possible, try to name your pull request by prefixing it with <SUBJECT>. For instance, if you're modifying the downloading, you could prefix it with u3d/download:
-->

### Pull Request Checklist

- [x] My pull request has been rebased on master
- [x] I ran `bundle exec rspec` to make sure that my PR didn't break any test
- [x] I ran `bundle exec rubocop` to make sure that my PR is inline with our code style
- [x] I have read the [code of conduct](https://github.com/DragonBox/u3d/blob/master/CODE_OF_CONDUCT.md)

### Pull Request Description

As `u3d console` is heavily inspired (👀) by fastlane own console command, it suffers from the same issue. With the upgrade to Ruby >= 3.3, IRB is changing the way its workspace is setup and this breaks the console command (see fastlane's issue [fastlane/fastlane#29924](https://github.com/fastlane/fastlane/issues/29924) for a more detailed description).

This PR fixes the console command by properly assigning its workspace and adds a spec file to validate the changes. All credit goes to @lacostej for [his own PR on fastlane](https://github.com/fastlane/fastlane/pull/29925), which I shamelessly copied here :)

This was validated locally against Ruby 2.6.10 and Ruby 3.3.6.